### PR TITLE
fix: enable SPA routing with Cloudflare Workers static assets

### DIFF
--- a/apps/web/wrangler.toml
+++ b/apps/web/wrangler.toml
@@ -12,6 +12,7 @@ command = "bun run build"
 
 [assets]
 directory = "dist"
+not_found_handling = "single-page-application"
 browser_TTL = 3600
 edge_TTL = 7200
 
@@ -24,5 +25,6 @@ BUILD_TIME = "{{BUILD_TIME}}"
 
 [env.production.assets]
 directory = "dist"
+not_found_handling = "single-page-application"
 browser_TTL = 3600
 edge_TTL = 7200


### PR DESCRIPTION
## Summary
- Fixed SPA routing issue where direct URL access (e.g., `/test1`) was showing "The application is loading" error
- Added `not_found_handling = "single-page-application"` configuration to wrangler.toml
- Enables TanStack Router to properly handle client-side navigation

## Changes Made
- Updated `apps/web/wrangler.toml` to include SPA handling configuration for both default and production environments
- Configured Cloudflare Workers static assets to automatically serve `index.html` for navigation requests

## Test Plan
- [x] Build completes successfully
- [ ] Direct URL access works (e.g., myzine.app/test1)
- [ ] Client-side navigation continues to work
- [ ] Static assets load correctly

## Technical Details
Based on [Cloudflare's SPA documentation](https://developers.cloudflare.com/workers/static-assets/routing/single-page-application/), the `not_found_handling = "single-page-application"` setting automatically serves the index.html file for navigation requests that don't match static assets, allowing TanStack Router to handle client-side routing properly.

🤖 Generated with [Claude Code](https://claude.ai/code)