### PR TITLE
fix: resolve foreign key constraint error when saving bookmarks

### DIFF
--- a/packages/api/src/d1-repository.ts
+++ b/packages/api/src/d1-repository.ts
@@ -423,4 +423,36 @@ export class D1BookmarkRepository implements BookmarkRepository {
 
     return bookmark
   }
+
+  /**
+   * Ensure user exists in the database - creates user if not exists
+   */
+  async ensureUser(userData: {
+    id: string
+    email?: string
+    firstName?: string
+    lastName?: string
+    imageUrl?: string
+  }): Promise<void> {
+    try {
+      const now = Date.now()
+      
+      await this.db.prepare(`
+        INSERT OR IGNORE INTO users (
+          id, email, first_name, last_name, image_url, created_at, updated_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?)
+      `).bind(
+        userData.id,
+        userData.email || '',
+        userData.firstName || null,
+        userData.lastName || null,
+        userData.imageUrl || null,
+        now,
+        now
+      ).run()
+    } catch (error) {
+      console.error('Error ensuring user exists:', error)
+      throw new Error('Failed to ensure user exists in database')
+    }
+  }
 }

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -129,6 +129,12 @@ app.post('/api/v1/bookmarks', async (c) => {
     const body = await c.req.json()
     const validatedData = CreateBookmarkSchema.parse(body)
     
+    // Ensure user exists in database before creating bookmark
+    const d1Repository = new D1BookmarkRepository(c.env.DB)
+    await d1Repository.ensureUser({
+      id: auth.userId
+    })
+    
     const result = await bookmarkService.createBookmark(validatedData, auth.userId)
     if (result.error) {
       return c.json({ error: result.error }, 500)
@@ -199,6 +205,12 @@ app.post('/api/v1/bookmarks/save', async (c) => {
     const body = await c.req.json()
     const validatedData = SaveBookmarkSchema.parse(body)
     
+    // Ensure user exists in database before creating bookmark
+    const d1Repository = new D1BookmarkRepository(c.env.DB)
+    await d1Repository.ensureUser({
+      id: auth.userId
+    })
+    
     // Ensure userId is set to authenticated user
     const saveData = {
       ...validatedData,
@@ -214,6 +226,7 @@ app.post('/api/v1/bookmarks/save', async (c) => {
           duplicate: result.duplicate 
         }, 409) // Conflict
       }
+      console.error('Error creating bookmark with metadata:', result.error)
       return c.json({ error: result.error }, 500)
     }
     
@@ -222,6 +235,7 @@ app.post('/api/v1/bookmarks/save', async (c) => {
       message: result.message 
     }, 201)
   } catch (error) {
+    console.error('Error creating bookmark with metadata:', error)
     return c.json({ error: 'Invalid request data' }, 400)
   }
 })


### PR DESCRIPTION
## Summary
- Fixed SQLITE_CONSTRAINT foreign key error when saving bookmarks in production
- Added automatic user creation to prevent foreign key violations
- Improved error logging for better debugging

## Root Cause
The `bookmarks` table has a foreign key constraint on `user_id` referencing the `users` table. When authenticated users tried to save bookmarks, their user records didn't exist in the database, causing foreign key constraint failures.

## Changes
- **Added `ensureUser()` method** to `D1BookmarkRepository` using `INSERT OR IGNORE` 
- **Modified POST endpoints** (`/api/v1/bookmarks` and `/api/v1/bookmarks/save`) to call `ensureUser()` before creating bookmarks
- **Enhanced error logging** in bookmark save endpoints for better debugging

## Test Plan
- [x] TypeScript compilation passes
- [x] Local development server starts successfully
- [x] Foreign key constraint issue resolved by ensuring user exists before bookmark creation
- [ ] Test bookmark creation in production environment
- [ ] Verify error logging provides useful debugging information

🤖 Generated with [Claude Code](https://claude.ai/code)