### PR TITLE
Fix: Foreign key constraint error when marking feed items as read

### DIFF
--- a/packages/api/src/d1-feed-item-repository.ts
+++ b/packages/api/src/d1-feed-item-repository.ts
@@ -370,6 +370,12 @@ export class D1FeedItemRepository implements FeedItemRepository {
         readAt: now
       }
     } else {
+      // Verify that the feed item exists before creating user feed item
+      const feedItem = await this.getFeedItem(feedItemId)
+      if (!feedItem) {
+        throw new Error(`Feed item ${feedItemId} not found`)
+      }
+      
       // Create new user feed item as read
       const userFeedItemId = `${userId}-${feedItemId}-${Date.now()}`
       return this.createUserFeedItem({
@@ -403,6 +409,12 @@ export class D1FeedItemRepository implements FeedItemRepository {
         readAt: undefined
       }
     } else {
+      // Verify that the feed item exists before creating user feed item
+      const feedItem = await this.getFeedItem(feedItemId)
+      if (!feedItem) {
+        throw new Error(`Feed item ${feedItemId} not found`)
+      }
+      
       // Create new user feed item as unread
       const userFeedItemId = `${userId}-${feedItemId}-${Date.now()}`
       return this.createUserFeedItem({

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -645,7 +645,12 @@ app.put('/api/v1/feed/:itemId/read', async (c) => {
     const auth = getAuthContext(c)
     const itemId = c.req.param('itemId')
     
-    const { feedItemRepository } = await initializeServices(c.env.DB, c.env)
+    const { feedItemRepository, subscriptionRepository } = await initializeServices(c.env.DB, c.env)
+    
+    // Ensure user exists in database before marking as read
+    await subscriptionRepository.ensureUser({
+      id: auth.userId
+    })
     
     await feedItemRepository.markAsRead(auth.userId, itemId)
     
@@ -661,7 +666,12 @@ app.put('/api/v1/feed/:itemId/unread', async (c) => {
     const auth = getAuthContext(c)
     const itemId = c.req.param('itemId')
     
-    const { feedItemRepository } = await initializeServices(c.env.DB, c.env)
+    const { feedItemRepository, subscriptionRepository } = await initializeServices(c.env.DB, c.env)
+    
+    // Ensure user exists in database before marking as unread
+    await subscriptionRepository.ensureUser({
+      id: auth.userId
+    })
     
     await feedItemRepository.markAsUnread(auth.userId, itemId)
     


### PR DESCRIPTION
## Summary
- Fixed foreign key constraint error that occurred when marking feed items as read
- Added validation to ensure feed item exists before creating user feed item record
- Added user existence check before marking items as read/unread

## Problem
When clicking "Mark Read" on a feed item, users were getting a 500 error with message:
```
Mark as read error: Error: D1_ERROR: FOREIGN KEY constraint failed: SQLITE_CONSTRAINT
```

## Root Cause
The `markAsRead` and `markAsUnread` methods in `D1FeedItemRepository` were attempting to create new `userFeedItems` records without verifying:
1. The feed item exists in the `feedItems` table
2. The user exists in the `users` table

This violates the foreign key constraints defined in the schema.

## Solution
1. Added validation in `markAsRead` and `markAsUnread` to check if the feed item exists before creating user feed item
2. Added `ensureUser` call in the API endpoints to ensure user exists in database before marking items

## Test plan
- [ ] Test marking a feed item as read - should succeed without errors
- [ ] Test marking a feed item as unread - should succeed without errors
- [ ] Test marking a non-existent feed item as read - should return appropriate error
- [ ] Verify foreign key constraints are properly enforced

🤖 Generated with [Claude Code](https://claude.ai/code)