### PR TITLE
fix: handle duplicate feed items before adding unique constraint

### DIFF
--- a/packages/api/migrations/0002_add_feed_items_unique_constraint.sql
+++ b/packages/api/migrations/0002_add_feed_items_unique_constraint.sql
@@ -1,4 +1,18 @@
--- Add unique constraint on subscription_id and external_id to prevent duplicate feed items
+-- First, remove duplicate feed items keeping only the most recent one
+DELETE FROM feed_items 
+WHERE id NOT IN (
+    SELECT MAX(id) 
+    FROM feed_items 
+    GROUP BY subscription_id, external_id
+);
+
+-- Also clean up any orphaned user_feed_items references
+DELETE FROM user_feed_items 
+WHERE feed_item_id NOT IN (
+    SELECT id FROM feed_items
+);
+
+-- Now add unique constraint on subscription_id and external_id to prevent duplicate feed items
 CREATE UNIQUE INDEX idx_feed_items_subscription_external ON feed_items(subscription_id, external_id);
 
 -- Add index for performance on subscription_id and published_at


### PR DESCRIPTION
## Summary
- Fixed the failing database migration in production that was preventing deployments
- Added cleanup of duplicate feed items before applying the unique constraint
- Ensures data integrity by removing orphaned user_feed_items references

## Problem
The `0002_add_feed_items_unique_constraint.sql` migration was failing with:
```
UNIQUE constraint failed: feed_items.subscription_id, feed_items.external_id
```

This was happening because there were existing duplicate entries in the production database.

## Solution
Modified the migration to:
1. Delete duplicate feed items, keeping only the most recent one (by ID)
2. Clean up any orphaned user_feed_items references
3. Then create the unique index as originally intended

## Test plan
- [x] Migration SQL syntax is valid
- [ ] GitHub Actions will test the migration on deployment
- [ ] Production deployment should succeed after merge

🤖 Generated with [Claude Code](https://claude.ai/code)