### PR TITLE
fix: convert Date objects to timestamps for D1 database operations

### DIFF
--- a/packages/api/src/repositories/batch-operations.ts
+++ b/packages/api/src/repositories/batch-operations.ts
@@ -83,10 +83,10 @@ export class BatchDatabaseOperations {
           title: feedItem.title,
           description: feedItem.description || null,
           thumbnailUrl: feedItem.thumbnailUrl || null,
-          publishedAt: feedItem.publishedAt,
+          publishedAt: feedItem.publishedAt.getTime(),
           durationSeconds: feedItem.durationSeconds || null,
           externalUrl: feedItem.externalUrl,
-          createdAt: now
+          createdAt: now.getTime()
         })
       }
     }
@@ -108,7 +108,7 @@ export class BatchDatabaseOperations {
             }))
           )
           return Array.from(recheckMap.values()).filter(item => 
-            item.createdAt.getTime() > now.getTime() - 1000
+            new Date(item.createdAt).getTime() > now.getTime() - 1000
           )
         }
         throw error
@@ -176,7 +176,7 @@ export class BatchDatabaseOperations {
             isRead: false,
             bookmarkId: null,
             readAt: null,
-            createdAt: now
+            createdAt: now.getTime()
           })
         }
       }
@@ -222,7 +222,7 @@ export class BatchDatabaseOperations {
       .from(schema.feedItems)
       .where(and(
         inArray(schema.feedItems.subscriptionId, subscriptionIds),
-        sql`${schema.feedItems.publishedAt} > ${cutoffTime}`
+        sql`${schema.feedItems.publishedAt} > ${cutoffTime.getTime()}`
       ))
 
     // Group by subscription ID


### PR DESCRIPTION
## Summary
- Fixes D1_TYPE_ERROR that occurs when cron job runs
- Converts JavaScript Date objects to timestamps before inserting into D1 database
- Maintains type safety by keeping Date objects in domain models

## Problem
D1 (Cloudflare's SQLite) doesn't support JavaScript Date objects directly. When the cron job runs, it attempts to insert Date objects into the database, causing:
```
D1_TYPE_ERROR: Type 'object' not supported for value 'Wed Jul 30 2025 00:35:57 GMT+0000 (Coordinated Universal Time)'
```

## Solution
- Convert Date objects to timestamps (milliseconds) at the database boundary
- Use `.getTime()` for all date fields when inserting into D1
- Keep Date objects in the domain models (FeedItem, UserFeedItem) for type safety

## Changes
1. In `batch-operations.ts`:
   - `publishedAt: feedItem.publishedAt.getTime()`
   - `createdAt: now.getTime()`
   - SQL comparison: `${cutoffTime.getTime()}`

## Test plan
- [x] Run type check: `bun run type-check` passes
- [ ] Deploy to staging and verify cron job runs without D1_TYPE_ERROR
- [ ] Confirm feed items are properly inserted with timestamps
- [ ] Verify date fields are correctly converted back to Date objects when reading

🤖 Generated with [Claude Code](https://claude.ai/code)