### PR TITLE
feat: populate initial feed content for new subscriptions

### DIFF
--- a/SUBSCRIPTION_FEATURE_DOCUMENTATION.md
+++ b/SUBSCRIPTION_FEATURE_DOCUMENTATION.md
@@ -1,0 +1,584 @@
+# Subscription Feature Documentation
+
+## Table of Contents
+1. [Overview](#overview)
+2. [Requirements](#requirements)
+3. [Architecture & Design](#architecture--design)
+4. [Implementation Details](#implementation-details)
+   - [Database Schema](#database-schema)
+   - [API Contract](#api-contract)
+   - [OAuth Flow](#oauth-flow)
+   - [Cron Job Processing](#cron-job-processing)
+   - [Frontend Implementation](#frontend-implementation)
+
+## Overview
+
+The subscription feature is a multi-provider content aggregation system that allows users to:
+- Connect their Spotify and YouTube accounts via OAuth
+- Discover and manage their podcast/channel subscriptions
+- View a unified feed of latest episodes/videos
+- Track read/unread states across all content
+- Save items to bookmarks for later reference
+
+The system automatically polls for new content hourly and maintains OAuth tokens with automatic refresh capabilities.
+
+## Requirements
+
+### Functional Requirements
+
+1. **OAuth Integration**
+   - Support Spotify (podcasts) and YouTube (channels) OAuth flows
+   - Secure token storage with encryption
+   - Automatic token refresh before expiry
+   - Manual token refresh capability
+   - Health monitoring for OAuth connections
+
+2. **Subscription Management**
+   - Discover user's existing subscriptions from connected providers
+   - Allow users to select which subscriptions to follow
+   - Display subscription metadata (thumbnails, creator names, descriptions)
+   - Track subscription state per user
+
+3. **Feed Aggregation**
+   - Fetch latest episodes/videos from all active subscriptions
+   - Deduplicate content to prevent duplicates
+   - Store feed items with metadata (duration, publish date, etc.)
+   - Support pagination for large feeds
+
+4. **User Experience**
+   - Unified feed view across all providers
+   - Per-subscription filtering
+   - Read/unread state tracking
+   - Unread count badges
+   - Save to bookmarks functionality
+   - Responsive design for all devices
+
+5. **Background Processing**
+   - Hourly cron job for content polling
+   - Automatic token refresh for expiring tokens
+   - Performance optimization for large-scale polling
+   - Error handling and retry logic
+
+### Non-Functional Requirements
+
+1. **Performance**
+   - Batch API calls (50 items per request)
+   - Caching layer for deduplication
+   - Query optimization with proper indexes
+   - Infinite scroll with efficient pagination
+
+2. **Security**
+   - Encrypted token storage
+   - State parameter validation for OAuth
+   - User isolation (no cross-user data access)
+   - Secure API endpoints with authentication
+
+3. **Scalability**
+   - Serverless architecture (Cloudflare Workers)
+   - Globally distributed infrastructure
+   - Efficient database queries
+   - Batch processing capabilities
+
+## Architecture & Design
+
+### System Architecture
+
+```
+┌─────────────────┐     ┌──────────────────┐     ┌─────────────────┐
+│   Frontend      │     │   API Gateway    │     │  External APIs  │
+│  (React SPA)    │────▶│  (Cloudflare     │────▶│   - Spotify     │
+│                 │     │   Workers)       │     │   - YouTube     │
+└─────────────────┘     └──────────────────┘     └─────────────────┘
+                               │
+                               ▼
+                        ┌──────────────────┐
+                        │   Database       │
+                        │ (Cloudflare D1)  │
+                        └──────────────────┘
+                               ▲
+                               │
+                        ┌──────────────────┐
+                        │   Cron Jobs      │
+                        │  (Scheduled)     │
+                        └──────────────────┘
+```
+
+### Key Design Patterns
+
+1. **Repository Pattern**: Clean abstraction between business logic and data access
+2. **Service Layer**: Business logic separated from controllers
+3. **Batch Processing**: Efficient handling of multiple API calls
+4. **Optimistic UI Updates**: Immediate feedback for user actions
+5. **Infinite Scroll**: Progressive data loading for large datasets
+
+### Technology Stack
+
+- **Frontend**: React + Vite + TanStack Router/Query
+- **Backend**: Cloudflare Workers + Hono
+- **Database**: Cloudflare D1 (SQLite)
+- **ORM**: Drizzle ORM
+- **Authentication**: Clerk
+- **OAuth**: Custom implementation with provider APIs
+
+## Implementation Details
+
+### Database Schema
+
+#### Core Tables
+
+```sql
+-- Users table (from Clerk)
+users (
+  id TEXT PRIMARY KEY,              -- Clerk user ID
+  email TEXT NOT NULL,
+  firstName TEXT,
+  lastName TEXT,
+  imageUrl TEXT,
+  createdAt TIMESTAMP NOT NULL,
+  updatedAt TIMESTAMP NOT NULL
+)
+
+-- OAuth providers configuration
+subscriptionProviders (
+  id TEXT PRIMARY KEY,              -- 'spotify' or 'youtube'
+  name TEXT NOT NULL,
+  oauthConfig TEXT NOT NULL,        -- JSON config
+  createdAt TIMESTAMP NOT NULL
+)
+
+-- User OAuth accounts
+userAccounts (
+  id TEXT PRIMARY KEY,
+  userId TEXT NOT NULL REFERENCES users(id),
+  providerId TEXT NOT NULL REFERENCES subscriptionProviders(id),
+  externalAccountId TEXT NOT NULL,
+  accessToken TEXT NOT NULL,
+  refreshToken TEXT,
+  expiresAt TIMESTAMP,
+  createdAt TIMESTAMP NOT NULL,
+  updatedAt TIMESTAMP NOT NULL
+)
+
+-- Available subscriptions from providers
+subscriptions (
+  id TEXT PRIMARY KEY,
+  providerId TEXT NOT NULL REFERENCES subscriptionProviders(id),
+  externalId TEXT NOT NULL,         -- Provider's ID
+  title TEXT NOT NULL,
+  creatorName TEXT NOT NULL,
+  description TEXT,
+  thumbnailUrl TEXT,
+  subscriptionUrl TEXT,
+  totalEpisodes INTEGER,
+  createdAt TIMESTAMP NOT NULL
+)
+
+-- User's selected subscriptions
+userSubscriptions (
+  id TEXT PRIMARY KEY,
+  userId TEXT NOT NULL REFERENCES users(id),
+  subscriptionId TEXT NOT NULL REFERENCES subscriptions(id),
+  isActive BOOLEAN NOT NULL DEFAULT true,
+  createdAt TIMESTAMP NOT NULL,
+  updatedAt TIMESTAMP NOT NULL
+)
+
+-- Feed items (episodes/videos)
+feedItems (
+  id TEXT PRIMARY KEY,
+  subscriptionId TEXT NOT NULL REFERENCES subscriptions(id),
+  externalId TEXT NOT NULL,
+  title TEXT NOT NULL,
+  description TEXT,
+  thumbnailUrl TEXT,
+  publishedAt TIMESTAMP NOT NULL,
+  durationSeconds INTEGER,
+  externalUrl TEXT NOT NULL,
+  createdAt TIMESTAMP NOT NULL
+)
+
+-- User's read/unread state
+userFeedItems (
+  id TEXT PRIMARY KEY,
+  userId TEXT NOT NULL REFERENCES users(id),
+  feedItemId TEXT NOT NULL REFERENCES feedItems(id),
+  isRead BOOLEAN NOT NULL DEFAULT false,
+  bookmarkId INTEGER REFERENCES bookmarks(id),
+  readAt TIMESTAMP,
+  createdAt TIMESTAMP NOT NULL
+)
+```
+
+### API Contract
+
+#### OAuth Endpoints
+
+**1. Initiate OAuth Connection**
+```http
+POST /api/v1/auth/:provider/connect
+Authorization: Bearer {clerk_token}
+Content-Type: application/json
+
+{
+  "redirectUrl": "https://app.example.com/feed" // optional
+}
+
+Response:
+{
+  "authUrl": "https://accounts.spotify.com/authorize?..."
+}
+```
+
+**2. OAuth Callback**
+```http
+GET /api/v1/auth/:provider/callback?code={code}&state={state}
+
+Response: Redirect to frontend with status
+```
+
+**3. Disconnect Account**
+```http
+DELETE /api/v1/auth/:provider/disconnect
+Authorization: Bearer {clerk_token}
+
+Response:
+{
+  "message": "Account disconnected successfully"
+}
+```
+
+**4. Manual Token Refresh**
+```http
+POST /api/v1/auth/:provider/refresh
+Authorization: Bearer {clerk_token}
+
+Response:
+{
+  "success": true,
+  "message": "Token refreshed successfully",
+  "account": {
+    "id": "...",
+    "provider": "spotify",
+    "expiresAt": "2024-01-01T00:00:00Z",
+    "hasRefreshToken": true
+  },
+  "wasRefreshed": true
+}
+```
+
+**5. OAuth Health Check**
+```http
+GET /api/v1/auth/health
+Authorization: Bearer {clerk_token}
+
+Response:
+{
+  "userId": "user_123",
+  "timestamp": "2024-01-01T00:00:00Z",
+  "providers": [
+    {
+      "provider": "spotify",
+      "connected": true,
+      "tokenStatus": "valid",
+      "expiresAt": "2024-01-01T00:00:00Z",
+      "timeUntilExpiry": "23 hours",
+      "requiresAttention": false
+    }
+  ],
+  "summary": {
+    "totalProviders": 2,
+    "connectedProviders": 1,
+    "overallHealth": "healthy"
+  }
+}
+```
+
+#### Subscription Management Endpoints
+
+**1. Discover Subscriptions**
+```http
+GET /api/v1/subscriptions/discover/:provider
+Authorization: Bearer {clerk_token}
+
+Response:
+{
+  "provider": "spotify",
+  "totalFound": 25,
+  "subscriptions": [
+    {
+      "id": "sub_123",
+      "externalId": "show_abc",
+      "title": "Podcast Name",
+      "creatorName": "Creator Name",
+      "description": "...",
+      "thumbnailUrl": "https://...",
+      "isAlreadySubscribed": false,
+      "totalEpisodes": 150
+    }
+  ],
+  "existingSubscriptions": ["sub_456"],
+  "newSubscriptions": ["sub_123"]
+}
+```
+
+**2. Get User Subscriptions**
+```http
+GET /api/v1/subscriptions
+Authorization: Bearer {clerk_token}
+
+Response:
+{
+  "subscriptions": [
+    {
+      "id": "sub_123",
+      "providerId": "spotify",
+      "title": "Podcast Name",
+      "creatorName": "Creator Name",
+      "thumbnailUrl": "https://...",
+      "isActive": true
+    }
+  ]
+}
+```
+
+**3. Update Subscriptions**
+```http
+POST /api/v1/subscriptions/:provider/update
+Authorization: Bearer {clerk_token}
+Content-Type: application/json
+
+{
+  "subscriptionIds": ["sub_123", "sub_456"]
+}
+
+Response:
+{
+  "message": "Subscriptions updated successfully",
+  "added": 2,
+  "removed": 1,
+  "total": 5
+}
+```
+
+#### Feed Endpoints
+
+**1. Get Feed**
+```http
+GET /api/v1/feed?unread=true&subscription=sub_123&limit=20&offset=0
+Authorization: Bearer {clerk_token}
+
+Response:
+{
+  "feedItems": [
+    {
+      "id": "ufi_123",
+      "feedItem": {
+        "id": "fi_123",
+        "title": "Episode Title",
+        "description": "...",
+        "thumbnailUrl": "https://...",
+        "publishedAt": "2024-01-01T00:00:00Z",
+        "durationSeconds": 1800,
+        "externalUrl": "https://...",
+        "subscription": {
+          "id": "sub_123",
+          "title": "Podcast Name",
+          "creatorName": "Creator Name",
+          "providerId": "spotify"
+        }
+      },
+      "isRead": false,
+      "readAt": null,
+      "bookmarkId": null
+    }
+  ],
+  "pagination": {
+    "offset": 0,
+    "limit": 20,
+    "total": 150,
+    "hasMore": true
+  }
+}
+```
+
+**2. Mark as Read**
+```http
+PUT /api/v1/feed/:itemId/read
+Authorization: Bearer {clerk_token}
+
+Response:
+{
+  "message": "Item marked as read"
+}
+```
+
+**3. Get Subscriptions with Unread Counts**
+```http
+GET /api/v1/feed/subscriptions
+Authorization: Bearer {clerk_token}
+
+Response:
+{
+  "subscriptions": [
+    {
+      "id": "sub_123",
+      "title": "Podcast Name",
+      "creatorName": "Creator Name",
+      "thumbnailUrl": "https://...",
+      "providerId": "spotify",
+      "unreadCount": 5,
+      "lastUpdated": "2024-01-01T00:00:00Z"
+    }
+  ]
+}
+```
+
+### OAuth Flow
+
+#### Spotify OAuth Configuration
+```javascript
+{
+  clientId: process.env.SPOTIFY_CLIENT_ID,
+  clientSecret: process.env.SPOTIFY_CLIENT_SECRET,
+  redirectUri: `${API_BASE_URL}/api/v1/auth/spotify/callback`,
+  scopes: ['user-read-playback-position', 'user-library-read'],
+  authUrl: 'https://accounts.spotify.com/authorize',
+  tokenUrl: 'https://accounts.spotify.com/api/token'
+}
+```
+
+#### YouTube OAuth Configuration
+```javascript
+{
+  clientId: process.env.YOUTUBE_CLIENT_ID,
+  clientSecret: process.env.YOUTUBE_CLIENT_SECRET,
+  redirectUri: `${API_BASE_URL}/api/v1/auth/youtube/callback`,
+  scopes: ['https://www.googleapis.com/auth/youtube.readonly'],
+  authUrl: 'https://accounts.google.com/o/oauth2/v2/auth',
+  tokenUrl: 'https://oauth2.googleapis.com/token'
+}
+```
+
+#### OAuth Flow Steps
+1. User initiates connection → Generate state token with 5-minute expiry
+2. Redirect to provider's OAuth page
+3. User authorizes → Provider redirects to callback
+4. Validate state token and exchange code for tokens
+5. Store tokens encrypted in database
+6. Fetch user info from provider
+7. Redirect user to frontend with success status
+
+### Cron Job Processing
+
+#### Schedule
+```toml
+[triggers]
+crons = ["0 * * * *"]  # Every hour at minute 0
+```
+
+#### Feed Polling Service (OptimizedFeedPollingService)
+
+**Execution Flow:**
+1. Get all active subscriptions grouped by provider
+2. Warm cache with recent items (deduplication)
+3. For each provider:
+   - Get valid access token (refresh if needed)
+   - Batch process subscriptions (50 per batch)
+   - Fetch latest episodes/videos
+   - Deduplicate against cache
+   - Store new items in `feedItems`
+   - Create `userFeedItems` for all subscribed users
+4. Return performance metrics
+
+**Performance Optimizations:**
+- Batch API calls (50 items per request)
+- Deduplication cache (20,000 items, 2-hour TTL)
+- Query optimization with proper indexes
+- Concurrent processing for multiple providers
+- Smart episode limit for Spotify (based on totalEpisodes)
+
+#### Token Refresh Service
+
+**Execution Flow:**
+1. Find tokens expiring within 1 hour
+2. Group by provider
+3. For each expiring token:
+   - Attempt refresh with exponential backoff
+   - Update database with new tokens
+   - Log failures for monitoring
+4. Return refresh statistics
+
+### Frontend Implementation
+
+#### Key Components
+
+**1. FeedPage Component**
+```typescript
+- Main container for feed display
+- Handles subscription filtering
+- Manages unread/all toggle
+- Coordinates with child components
+```
+
+**2. FeedItemList Component**
+```typescript
+- Renders feed items with infinite scroll
+- Handles read/unread actions
+- Save to bookmarks functionality
+- Empty states and loading states
+```
+
+**3. SubscriptionAvatars Component**
+```typescript
+- Visual subscription selector
+- Shows unread counts
+- Allows filtering by subscription
+```
+
+#### Data Management (useFeedManager Hook)
+
+```typescript
+const {
+  feedItems,              // Flattened array of all feed items
+  subscriptions,          // Array with unread counts
+  isLoading,             // Initial load state
+  isLoadingMore,         // Pagination load state
+  error,                 // Error state
+  hasMore,               // More items available
+  loadMore,              // Function to load next page
+  markAsRead,            // Mark item as read
+  markAsUnread,          // Mark item as unread
+  saveToBookmarks,       // Save to bookmarks
+  refetch                // Refresh data
+} = useFeedManager({
+  unreadOnly: true,
+  subscriptionId: 'sub_123',
+  limit: 20
+})
+```
+
+**Features:**
+- TanStack Query for data fetching
+- Optimistic updates for instant feedback
+- Infinite scroll with `useInfiniteQuery`
+- Real-time unread count updates
+- Error handling and retry logic
+
+#### State Management
+
+1. **Server State**: TanStack Query
+   - Caching and synchronization
+   - Background refetching
+   - Optimistic updates
+   - Request deduplication
+
+2. **URL State**: TanStack Router
+   - Subscription filtering via URL params
+   - Deep linking support
+   - Browser history integration
+
+3. **Local State**: React useState
+   - UI toggles (unread/all)
+   - Temporary UI states
+
+This architecture provides a robust, scalable subscription aggregation system with excellent user experience and performance characteristics.

--- a/packages/api/migrations/0002_flaky_doctor_spectrum.sql
+++ b/packages/api/migrations/0002_flaky_doctor_spectrum.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `subscriptions` ADD `total_episodes` integer;

--- a/packages/api/migrations/meta/0002_snapshot.json
+++ b/packages/api/migrations/meta/0002_snapshot.json
@@ -1,0 +1,842 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "45099245-49e0-4ebd-91d9-ae84ea141835",
+  "prevId": "7fa9adea-c068-4991-96e7-281e5eea1d2d",
+  "tables": {
+    "bookmarks": {
+      "name": "bookmarks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "original_url": {
+          "name": "original_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "thumbnail_url": {
+          "name": "thumbnail_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "favicon_url": {
+          "name": "favicon_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "video_metadata": {
+          "name": "video_metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "podcast_metadata": {
+          "name": "podcast_metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "article_metadata": {
+          "name": "article_metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "post_metadata": {
+          "name": "post_metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "bookmarks_user_id_users_id_fk": {
+          "name": "bookmarks_user_id_users_id_fk",
+          "tableFrom": "bookmarks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "creators": {
+      "name": "creators",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "platforms": {
+          "name": "platforms",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "external_links": {
+          "name": "external_links",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "feed_items": {
+      "name": "feed_items",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "subscription_id": {
+          "name": "subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "thumbnail_url": {
+          "name": "thumbnail_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "duration_seconds": {
+          "name": "duration_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "external_url": {
+          "name": "external_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "feed_items_subscription_id_subscriptions_id_fk": {
+          "name": "feed_items_subscription_id_subscriptions_id_fk",
+          "tableFrom": "feed_items",
+          "tableTo": "subscriptions",
+          "columnsFrom": [
+            "subscription_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "subscription_providers": {
+      "name": "subscription_providers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "oauth_config": {
+          "name": "oauth_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "subscriptions": {
+      "name": "subscriptions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "creator_name": {
+          "name": "creator_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "thumbnail_url": {
+          "name": "thumbnail_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "subscription_url": {
+          "name": "subscription_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_episodes": {
+          "name": "total_episodes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "subscriptions_provider_id_subscription_providers_id_fk": {
+          "name": "subscriptions_provider_id_subscription_providers_id_fk",
+          "tableFrom": "subscriptions",
+          "tableTo": "subscription_providers",
+          "columnsFrom": [
+            "provider_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_accounts": {
+      "name": "user_accounts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "external_account_id": {
+          "name": "external_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_accounts_user_id_users_id_fk": {
+          "name": "user_accounts_user_id_users_id_fk",
+          "tableFrom": "user_accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "user_accounts_provider_id_subscription_providers_id_fk": {
+          "name": "user_accounts_provider_id_subscription_providers_id_fk",
+          "tableFrom": "user_accounts",
+          "tableTo": "subscription_providers",
+          "columnsFrom": [
+            "provider_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_feed_items": {
+      "name": "user_feed_items",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "feed_item_id": {
+          "name": "feed_item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_read": {
+          "name": "is_read",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "bookmark_id": {
+          "name": "bookmark_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_feed_items_user_id_users_id_fk": {
+          "name": "user_feed_items_user_id_users_id_fk",
+          "tableFrom": "user_feed_items",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "user_feed_items_feed_item_id_feed_items_id_fk": {
+          "name": "user_feed_items_feed_item_id_feed_items_id_fk",
+          "tableFrom": "user_feed_items",
+          "tableTo": "feed_items",
+          "columnsFrom": [
+            "feed_item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "user_feed_items_bookmark_id_bookmarks_id_fk": {
+          "name": "user_feed_items_bookmark_id_bookmarks_id_fk",
+          "tableFrom": "user_feed_items",
+          "tableTo": "bookmarks",
+          "columnsFrom": [
+            "bookmark_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_subscriptions": {
+      "name": "user_subscriptions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "subscription_id": {
+          "name": "subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_subscriptions_user_id_users_id_fk": {
+          "name": "user_subscriptions_user_id_users_id_fk",
+          "tableFrom": "user_subscriptions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "user_subscriptions_subscription_id_subscriptions_id_fk": {
+          "name": "user_subscriptions_subscription_id_subscriptions_id_fk",
+          "tableFrom": "user_subscriptions",
+          "tableTo": "subscriptions",
+          "columnsFrom": [
+            "subscription_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/api/migrations/meta/_journal.json
+++ b/packages/api/migrations/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1753650855911,
       "tag": "0001_plain_ma_gnuci",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "6",
+      "when": 1754268945264,
+      "tag": "0002_flaky_doctor_spectrum",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -19,6 +19,7 @@ import { SubscriptionDiscoveryService } from './services/subscription-discovery-
 import { OptimizedFeedPollingService } from './services/optimized-feed-polling-service'
 import { TokenRefreshService } from './services/token-refresh-service'
 import { QueryOptimizer } from './repositories/query-optimizer'
+import { InitialFeedPopulationService } from './services/initial-feed-population-service'
 
 type Bindings = {
   DB: D1Database
@@ -56,6 +57,7 @@ let subscriptionDiscoveryService: SubscriptionDiscoveryService
 let feedPollingService: OptimizedFeedPollingService
 let tokenRefreshService: TokenRefreshService
 let queryOptimizer: QueryOptimizer
+let initialFeedPopulationService: InitialFeedPopulationService
 
 // Initialize services on first request
 async function initializeServices(db: D1Database, env: Bindings) {
@@ -69,6 +71,7 @@ async function initializeServices(db: D1Database, env: Bindings) {
     feedPollingService = new OptimizedFeedPollingService(subscriptionRepository, feedItemRepository, db)
     tokenRefreshService = new TokenRefreshService(subscriptionRepository)
     queryOptimizer = new QueryOptimizer(db)
+    initialFeedPopulationService = new InitialFeedPopulationService(subscriptionRepository, feedItemRepository)
     
     // Setup database tables and providers
     await setupDatabase(db)
@@ -83,7 +86,8 @@ async function initializeServices(db: D1Database, env: Bindings) {
     feedItemRepository,
     subscriptionDiscoveryService,
     feedPollingService,
-    tokenRefreshService
+    tokenRefreshService,
+    initialFeedPopulationService
   }
 }
 
@@ -560,13 +564,31 @@ app.post('/api/v1/subscriptions/:provider/update', async (c) => {
       return c.json({ error: 'subscriptions must be an array' }, 400)
     }
     
-    const { subscriptionDiscoveryService } = await initializeServices(c.env.DB, c.env)
+    const { subscriptionDiscoveryService, initialFeedPopulationService } = await initializeServices(c.env.DB, c.env)
     
     const result = await subscriptionDiscoveryService.updateUserSubscriptions(
       auth.userId,
       provider,
       subscriptions
     )
+    
+    // If new subscriptions were added, populate initial feed with content from last 24 hours
+    if (result.newSubscriptionIds.length > 0) {
+      console.log(`[SubscriptionUpdate] Populating initial feed for ${result.newSubscriptionIds.length} new subscriptions`)
+      
+      try {
+        const populationResults = await initialFeedPopulationService.populateInitialFeedForUser(
+          auth.userId,
+          result.newSubscriptionIds
+        )
+        
+        const totalItemsAdded = populationResults.reduce((sum, r) => sum + r.itemsAdded, 0)
+        console.log(`[SubscriptionUpdate] Added ${totalItemsAdded} items to user's feed from last 24 hours`)
+      } catch (error) {
+        // Log error but don't fail the subscription update
+        console.error('[SubscriptionUpdate] Error populating initial feed:', error)
+      }
+    }
     
     return c.json({
       message: 'Subscriptions updated successfully',

--- a/packages/api/src/services/initial-feed-population-service.ts
+++ b/packages/api/src/services/initial-feed-population-service.ts
@@ -1,0 +1,215 @@
+import { SubscriptionRepository, FeedItemRepository, UserAccount } from '@zine/shared'
+import { SpotifyAPI } from '../external/spotify-api'
+import { YouTubeAPI } from '../external/youtube-api'
+
+export interface InitialFeedPopulationResult {
+  subscriptionId: string
+  subscriptionTitle: string
+  itemsAdded: number
+  error?: string
+}
+
+export class InitialFeedPopulationService {
+  constructor(
+    private subscriptionRepository: SubscriptionRepository,
+    private feedItemRepository: FeedItemRepository
+  ) {}
+
+  async populateInitialFeedForUser(
+    userId: string,
+    subscriptionIds: string[]
+  ): Promise<InitialFeedPopulationResult[]> {
+    const results: InitialFeedPopulationResult[] = []
+    const twentyFourHoursAgo = new Date()
+    twentyFourHoursAgo.setHours(twentyFourHoursAgo.getHours() - 24)
+
+    console.log(`[InitialFeedPopulation] Populating initial feed for user ${userId} with ${subscriptionIds.length} subscriptions`)
+
+    // Group subscriptions by provider
+    const subscriptionsByProvider = new Map<string, string[]>()
+    
+    for (const subscriptionId of subscriptionIds) {
+      const subscription = await this.subscriptionRepository.getSubscription(subscriptionId)
+      if (!subscription) continue
+      
+      const providerSubs = subscriptionsByProvider.get(subscription.providerId) || []
+      providerSubs.push(subscriptionId)
+      subscriptionsByProvider.set(subscription.providerId, providerSubs)
+    }
+
+    // Process each provider
+    for (const [providerId, subIds] of subscriptionsByProvider) {
+      const userAccount = await this.subscriptionRepository.getValidUserAccount(userId, providerId)
+      if (!userAccount) {
+        console.error(`[InitialFeedPopulation] No valid account for provider ${providerId}`)
+        continue
+      }
+
+      if (providerId === 'spotify') {
+        const spotifyResults = await this.populateSpotifyFeeds(subIds, userAccount, twentyFourHoursAgo, userId)
+        results.push(...spotifyResults)
+      } else if (providerId === 'youtube') {
+        const youtubeResults = await this.populateYouTubeFeeds(subIds, userAccount, twentyFourHoursAgo, userId)
+        results.push(...youtubeResults)
+      }
+    }
+
+    console.log(`[InitialFeedPopulation] Completed initial feed population for user ${userId}. Total items added: ${results.reduce((sum, r) => sum + r.itemsAdded, 0)}`)
+    
+    return results
+  }
+
+  private async populateSpotifyFeeds(
+    subscriptionIds: string[],
+    userAccount: UserAccount,
+    cutoffDate: Date,
+    userId: string
+  ): Promise<InitialFeedPopulationResult[]> {
+    const results: InitialFeedPopulationResult[] = []
+    const spotifyAPI = new SpotifyAPI(userAccount.accessToken)
+
+    for (const subscriptionId of subscriptionIds) {
+      try {
+        const subscription = await this.subscriptionRepository.getSubscription(subscriptionId)
+        if (!subscription) continue
+
+        // Fetch latest episodes (limited to 20)
+        const episodes = await spotifyAPI.getLatestEpisodes(subscription.externalId, 20)
+        
+        // Filter to only episodes from the last 24 hours
+        const recentEpisodes = episodes.filter(episode => {
+          const publishedAt = new Date(episode.release_date)
+          return publishedAt >= cutoffDate
+        })
+
+        console.log(`[InitialFeedPopulation] Found ${recentEpisodes.length} recent episodes for ${subscription.title}`)
+
+        // Create feed items for recent episodes
+        const feedItems = []
+        for (const episode of recentEpisodes) {
+          const feedItem = await this.feedItemRepository.findOrCreateFeedItem({
+            subscriptionId: subscription.id,
+            externalId: episode.id,
+            title: episode.name,
+            description: episode.description,
+            thumbnailUrl: episode.images?.[0]?.url,
+            publishedAt: new Date(episode.release_date),
+            durationSeconds: Math.round(episode.duration_ms / 1000),
+            externalUrl: episode.external_urls.spotify
+          })
+
+          // Check if this is actually new (created within last 5 seconds)
+          const isNew = feedItem.createdAt.getTime() > Date.now() - 5000
+          if (isNew) {
+            feedItems.push(feedItem)
+          }
+        }
+
+        // Create user feed items
+        if (feedItems.length > 0) {
+          const userFeedItems = feedItems.map(feedItem => ({
+            id: `${userId}-${feedItem.id}`,
+            userId,
+            feedItemId: feedItem.id,
+            isRead: false
+          }))
+
+          await this.feedItemRepository.createUserFeedItems(userFeedItems)
+        }
+
+        results.push({
+          subscriptionId: subscription.id,
+          subscriptionTitle: subscription.title,
+          itemsAdded: feedItems.length
+        })
+      } catch (error) {
+        const subscription = await this.subscriptionRepository.getSubscription(subscriptionId)
+        results.push({
+          subscriptionId,
+          subscriptionTitle: subscription?.title || 'Unknown',
+          itemsAdded: 0,
+          error: error instanceof Error ? error.message : 'Unknown error'
+        })
+      }
+    }
+
+    return results
+  }
+
+  private async populateYouTubeFeeds(
+    subscriptionIds: string[],
+    userAccount: UserAccount,
+    cutoffDate: Date,
+    userId: string
+  ): Promise<InitialFeedPopulationResult[]> {
+    const results: InitialFeedPopulationResult[] = []
+    const youtubeAPI = new YouTubeAPI(userAccount.accessToken)
+
+    for (const subscriptionId of subscriptionIds) {
+      try {
+        const subscription = await this.subscriptionRepository.getSubscription(subscriptionId)
+        if (!subscription) continue
+
+        // Fetch latest videos (limited to 20)
+        const videos = await youtubeAPI.getLatestVideos(subscription.externalId, 20)
+        
+        // Filter to only videos from the last 24 hours
+        const recentVideos = videos.filter(video => {
+          const publishedAt = new Date(video.snippet.publishedAt)
+          return publishedAt >= cutoffDate
+        })
+
+        console.log(`[InitialFeedPopulation] Found ${recentVideos.length} recent videos for ${subscription.title}`)
+
+        // Create feed items for recent videos
+        const feedItems = []
+        for (const video of recentVideos) {
+          const feedItem = await this.feedItemRepository.findOrCreateFeedItem({
+            subscriptionId: subscription.id,
+            externalId: video.id,
+            title: video.snippet.title,
+            description: video.snippet.description,
+            thumbnailUrl: video.snippet.thumbnails?.medium?.url || video.snippet.thumbnails?.default?.url,
+            publishedAt: new Date(video.snippet.publishedAt),
+            durationSeconds: YouTubeAPI.parseDuration(video.contentDetails.duration),
+            externalUrl: `https://youtube.com/watch?v=${video.id}`
+          })
+
+          // Check if this is actually new (created within last 5 seconds)
+          const isNew = feedItem.createdAt.getTime() > Date.now() - 5000
+          if (isNew) {
+            feedItems.push(feedItem)
+          }
+        }
+
+        // Create user feed items
+        if (feedItems.length > 0) {
+          const userFeedItems = feedItems.map(feedItem => ({
+            id: `${userId}-${feedItem.id}`,
+            userId,
+            feedItemId: feedItem.id,
+            isRead: false
+          }))
+
+          await this.feedItemRepository.createUserFeedItems(userFeedItems)
+        }
+
+        results.push({
+          subscriptionId: subscription.id,
+          subscriptionTitle: subscription.title,
+          itemsAdded: feedItems.length
+        })
+      } catch (error) {
+        const subscription = await this.subscriptionRepository.getSubscription(subscriptionId)
+        results.push({
+          subscriptionId,
+          subscriptionTitle: subscription?.title || 'Unknown',
+          itemsAdded: 0,
+          error: error instanceof Error ? error.message : 'Unknown error'
+        })
+      }
+    }
+
+    return results
+  }
+}

--- a/packages/api/src/services/subscription-discovery-service.ts
+++ b/packages/api/src/services/subscription-discovery-service.ts
@@ -181,9 +181,10 @@ export class SubscriptionDiscoveryService {
       selected: boolean
       totalEpisodes?: number
     }>
-  ): Promise<{ added: number; removed: number }> {
+  ): Promise<{ added: number; removed: number; newSubscriptionIds: string[] }> {
     let added = 0
     let removed = 0
+    const newSubscriptionIds: string[] = []
 
     for (const choice of subscriptionChoices) {
       // Find or create the subscription in our database
@@ -212,12 +213,14 @@ export class SubscriptionDiscoveryService {
             isActive: true
           })
           added++
+          newSubscriptionIds.push(subscription.id)
         } else if (!existingUserSub.isActive) {
           // Reactivate existing subscription
           await this.subscriptionRepository.updateUserSubscription(existingUserSub.id, {
             isActive: true
           })
           added++
+          newSubscriptionIds.push(subscription.id)
         }
       } else {
         if (existingUserSub && existingUserSub.isActive) {
@@ -230,7 +233,7 @@ export class SubscriptionDiscoveryService {
       }
     }
 
-    return { added, removed }
+    return { added, removed, newSubscriptionIds }
   }
 
 }

--- a/packages/api/wrangler.toml
+++ b/packages/api/wrangler.toml
@@ -13,7 +13,7 @@ ENVIRONMENT = "development"
 # Cron triggers for scheduled tasks
 [triggers]
 crons = [
-  "0 * * * *"     # Every hour - both feed polling and token refresh
+  "*/5 * * * *"   # Every 5 minutes - both feed polling and token refresh
 ]
 
 [[d1_databases]]


### PR DESCRIPTION
## Summary
- Automatically populate user feeds with content from the last 24 hours when they add new subscriptions
- Ensures users immediately see recent episodes/videos from their newly added subscriptions
- Updates cron schedule to run every 5 minutes for more timely content updates

## Changes
- ✨ Added `InitialFeedPopulationService` to fetch and populate recent content from new subscriptions
- 🔄 Integrated initial feed population into the subscription update flow
- 📊 Added `total_episodes` column to subscriptions table for better tracking
- ⏰ Updated cron schedule from hourly to every 5 minutes
- 📚 Added comprehensive subscription feature documentation

## Technical Details
The new service:
- Fetches up to 20 latest items from each new subscription
- Filters to only include content from the last 24 hours
- Deduplicates content to avoid showing already-existing items
- Creates user feed items for immediate visibility
- Handles errors gracefully without blocking subscription updates

## Test Plan
- [x] Type-check passes
- [x] Build completes successfully
- [ ] Manually test adding new subscriptions to verify initial content appears
- [ ] Verify cron job runs successfully every 5 minutes
- [ ] Check that only content from last 24 hours is populated

🤖 Generated with [Claude Code](https://claude.ai/code)