### PR TITLE
fix: resolve type-check errors in batch-operations

### DIFF
--- a/packages/api/src/repositories/batch-operations.ts
+++ b/packages/api/src/repositories/batch-operations.ts
@@ -1,5 +1,5 @@
 import { drizzle } from 'drizzle-orm/d1'
-import { eq, and, inArray, sql, or, gt } from 'drizzle-orm'
+import { eq, and, inArray, or, gt } from 'drizzle-orm'
 import * as schema from '../schema'
 import { FeedItem } from '@zine/shared'
 
@@ -355,7 +355,7 @@ export class BatchDatabaseOperations {
           .from(schema.feedItems)
           .where(and(
             inArray(schema.feedItems.subscriptionId, chunk),
-            gt(schema.feedItems.publishedAt, cutoffTime.getTime())
+            gt(schema.feedItems.publishedAt, cutoffTime)
           ))
         
         console.log(`[BatchOps:getRecentFeedItemIds] Chunk ${chunkNum} returned ${recentItems.length} items`)


### PR DESCRIPTION
## Summary
- Remove unused `sql` import from batch-operations.ts
- Fix Date type comparison by removing unnecessary `.getTime()` call

## Test plan
- [x] Run `turbo type-check` - all type errors resolved
- [x] Run `turbo build` - builds successfully
- [x] No test suite configured in project

🤖 Generated with [Claude Code](https://claude.ai/code)