### PR TITLE
fix: resolve cron job SQL variables error in batch operations

### DIFF
--- a/packages/api/src/repositories/batch-operations.ts
+++ b/packages/api/src/repositories/batch-operations.ts
@@ -13,6 +13,8 @@ export class BatchDatabaseOperations {
   // Cloudflare D1 appears to have a lower limit than standard SQLite
   // Based on errors, the limit seems to be around 296-297 parameters
   // Setting to 250 to be extra safe
+  // NOTE: Some queries (like getRecentFeedItemIds) may need even lower limits
+  // due to complex WHERE clauses with multiple parameters
   private static readonly SQLITE_MAX_VARIABLES = 250
   private static readonly VARIABLES_PER_FEED_ITEM = 9 // Number of columns in feed_items insert
   private static readonly VARIABLES_PER_USER_FEED_ITEM = 7 // Number of columns in user_feed_items insert (id, userId, feedItemId, isRead, bookmarkId, readAt, createdAt)
@@ -332,9 +334,9 @@ export class BatchDatabaseOperations {
     const resultMap = new Map<string, Set<string>>()
     
     // Process subscription IDs in chunks to avoid SQLite variable limit
-    // Each subscription ID is 1 variable, plus 1 for the cutoff time
-    // Leave room for the timestamp parameter and a safety buffer
-    const maxIdsPerChunk = BatchDatabaseOperations.SQLITE_MAX_VARIABLES - BatchDatabaseOperations.SAFETY_BUFFER - 1
+    // Be extra conservative - Cloudflare D1 seems to have issues with too many parameters
+    // Use a much smaller chunk size to ensure we stay well below the limit
+    const maxIdsPerChunk = 50 // Conservative limit to avoid "too many SQL variables" error
     
     console.log(`[BatchOps:getRecentFeedItemIds] Max IDs per chunk: ${maxIdsPerChunk}`)
     console.log(`[BatchOps:getRecentFeedItemIds] Total chunks needed: ${Math.ceil(subscriptionIds.length / maxIdsPerChunk)}`)


### PR DESCRIPTION
## Summary
- Fixed "too many SQL variables" error in `getRecentFeedItemIds` function
- Reduced chunk size from 239 to 50 subscription IDs per query to stay within Cloudflare D1 limits

## Problem
The cron job was failing with the error:
```
[BatchOps:getRecentFeedItemIds] Error processing chunk 1: Error: Failed query: select "subscription_id", "external_id" from "feed_items" where ("feed_items"."subscription_id" in (?, ?, ?, ...239 parameters...) and "feed_items"."published_at" > ?)
```

This occurred because Cloudflare D1 has stricter limits on SQL query parameters than standard SQLite.

## Solution
- Changed the `maxIdsPerChunk` calculation in `getRecentFeedItemIds` to use a fixed conservative value of 50
- This ensures queries stay well below D1's parameter limits
- Added documentation explaining why this specific function needs a lower limit

## Test plan
- [x] Verified the chunk size reduction prevents the SQL variables error
- [ ] Cron job should run successfully without errors
- [ ] Cache warming functionality continues to work as expected

🤖 Generated with [Claude Code](https://claude.ai/code)