### PR TITLE
Optimize Spotify podcast polling with batch fetching

### DIFF
--- a/packages/api/src/durable-objects/single-user-polling-service.ts
+++ b/packages/api/src/durable-objects/single-user-polling-service.ts
@@ -1,5 +1,5 @@
 import { Subscription } from '@zine/shared'
-import { SpotifyAPI } from '../external/spotify-api'
+import { SpotifyAPI, SpotifyShow } from '../external/spotify-api'
 import { YouTubeAPI } from '../external/youtube-api'
 import { OAuthTokenData } from './user-subscription-manager'
 import type { Env } from '../types'
@@ -124,52 +124,149 @@ export class SingleUserPollingService {
   ): Promise<UserPollResult[]> {
     const results: UserPollResult[] = []
     const spotifyAPI = new SpotifyAPI(token.accessToken)
+    const MAX_BATCH_SIZE = 50 // Spotify's limit for batch show fetching
+    const MAX_EPISODE_CONCURRENT = 5 // Limit concurrent episode fetches to avoid timeouts
+    let subrequestCount = 0
+    const MAX_SUBREQUESTS = 45 // Conservative limit (Cloudflare allows 50)
 
-    for (const subscription of subscriptions) {
+    console.log(`[SingleUserPolling] Batch processing ${subscriptions.length} Spotify subscriptions`)
+
+    // Step 1: Batch fetch all show metadata
+    const showIds = subscriptions.map(s => s.externalId)
+    const showBatches = this.chunk(showIds, MAX_BATCH_SIZE)
+    const allShows = new Map<string, SpotifyShow>()
+
+    for (const batch of showBatches) {
+      if (subrequestCount >= MAX_SUBREQUESTS) {
+        console.warn(`[SingleUserPolling] Approaching subrequest limit, stopping show fetching`)
+        break
+      }
+      
       try {
-        // Fetch show details and recent episodes
-        const show = await spotifyAPI.getShow(subscription.externalId)
-        const episodes = await spotifyAPI.getShowEpisodes(subscription.externalId, 10)
-
-        // Check for new episodes
-        const newItems = await this.checkForNewItems(subscription.id, episodes.items.map(ep => ({
-          externalId: ep.id,
-          title: ep.name,
-          description: ep.description,
-          thumbnailUrl: ep.images?.[0]?.url || '',
-          publishedAt: new Date(ep.release_date),
-          durationSeconds: Math.floor(ep.duration_ms / 1000),
-          externalUrl: ep.external_urls.spotify
-        })))
-
-        // Create feed items for new episodes
-        if (newItems.length > 0) {
-          await this.createFeedItems(subscription.id, newItems)
-        }
-
-        results.push({
-          provider: 'spotify',
-          subscriptionId: subscription.id,
-          subscriptionTitle: subscription.title,
-          newItemsFound: newItems.length
-        })
-
-        // Update total episodes if changed
-        if (show.total_episodes !== subscription.totalEpisodes) {
-          await this.updateSubscriptionTotalEpisodes(subscription.id, show.total_episodes)
-        }
+        subrequestCount++
+        const shows = await this.getMultipleShows(spotifyAPI, batch)
+        shows.forEach(show => allShows.set(show.id, show))
       } catch (error) {
-        console.error(`[SingleUserPolling] Error polling Spotify subscription ${subscription.id}:`, error)
+        console.error(`[SingleUserPolling] Error fetching batch of shows:`, error)
+      }
+    }
+
+    console.log(`[SingleUserPolling] Fetched metadata for ${allShows.size} shows using ${subrequestCount} API calls`)
+
+    // Step 2: Identify shows with new episodes by comparing total_episodes
+    const showsNeedingEpisodeCheck: { subscription: Subscription; show: SpotifyShow }[] = []
+    
+    for (const subscription of subscriptions) {
+      const show = allShows.get(subscription.externalId)
+      if (!show) {
         results.push({
           provider: 'spotify',
           subscriptionId: subscription.id,
           subscriptionTitle: subscription.title,
           newItemsFound: 0,
-          errors: [error instanceof Error ? error.message : String(error)]
+          errors: ['Show not found or unavailable']
+        })
+        continue
+      }
+
+      // Check if show has new episodes
+      if (subscription.totalEpisodes === undefined || show.total_episodes > subscription.totalEpisodes) {
+        showsNeedingEpisodeCheck.push({ subscription, show })
+      } else {
+        // No new episodes, but still update total_episodes if different
+        if (show.total_episodes !== subscription.totalEpisodes) {
+          await this.updateSubscriptionTotalEpisodes(subscription.id, show.total_episodes)
+        }
+        results.push({
+          provider: 'spotify',
+          subscriptionId: subscription.id,
+          subscriptionTitle: subscription.title,
+          newItemsFound: 0
         })
       }
     }
 
+    console.log(`[SingleUserPolling] ${showsNeedingEpisodeCheck.length} shows have potential new episodes`)
+
+    // Step 3: Fetch episodes only for shows with changes (with concurrency limit)
+    const episodeBatches = this.chunk(showsNeedingEpisodeCheck, MAX_EPISODE_CONCURRENT)
+    
+    for (const batch of episodeBatches) {
+      if (subrequestCount >= MAX_SUBREQUESTS) {
+        console.warn(`[SingleUserPolling] Subrequest limit reached, stopping episode fetching`)
+        // Add remaining subscriptions as skipped
+        for (const { subscription } of batch) {
+          results.push({
+            provider: 'spotify',
+            subscriptionId: subscription.id,
+            subscriptionTitle: subscription.title,
+            newItemsFound: 0,
+            errors: ['Skipped due to API limit']
+          })
+        }
+        break
+      }
+
+      // Process batch concurrently
+      const batchPromises = batch.map(async ({ subscription, show }) => {
+        if (subrequestCount >= MAX_SUBREQUESTS) {
+          return {
+            provider: 'spotify' as const,
+            subscriptionId: subscription.id,
+            subscriptionTitle: subscription.title,
+            newItemsFound: 0,
+            errors: ['Skipped due to API limit']
+          }
+        }
+
+        try {
+          subrequestCount++
+          const episodes = await spotifyAPI.getShowEpisodes(subscription.externalId, 10)
+
+          // Check for new episodes
+          const newItems = await this.checkForNewItems(subscription.id, episodes.items.map(ep => ({
+            externalId: ep.id,
+            title: ep.name,
+            description: ep.description,
+            thumbnailUrl: ep.images?.[0]?.url || '',
+            publishedAt: new Date(ep.release_date),
+            durationSeconds: Math.floor(ep.duration_ms / 1000),
+            externalUrl: ep.external_urls.spotify
+          })))
+
+          // Create feed items for new episodes
+          if (newItems.length > 0) {
+            await this.createFeedItems(subscription.id, newItems)
+          }
+
+          // Update total episodes
+          if (show.total_episodes !== subscription.totalEpisodes) {
+            await this.updateSubscriptionTotalEpisodes(subscription.id, show.total_episodes)
+          }
+
+          return {
+            provider: 'spotify' as const,
+            subscriptionId: subscription.id,
+            subscriptionTitle: subscription.title,
+            newItemsFound: newItems.length
+          }
+        } catch (error) {
+          console.error(`[SingleUserPolling] Error polling episodes for ${subscription.id}:`, error)
+          return {
+            provider: 'spotify' as const,
+            subscriptionId: subscription.id,
+            subscriptionTitle: subscription.title,
+            newItemsFound: 0,
+            errors: [error instanceof Error ? error.message : String(error)]
+          }
+        }
+      })
+
+      const batchResults = await Promise.all(batchPromises)
+      results.push(...batchResults)
+    }
+
+    console.log(`[SingleUserPolling] Spotify polling complete. Total API calls: ${subrequestCount}/${MAX_SUBREQUESTS}`)
     return results
   }
 
@@ -331,5 +428,46 @@ export class SingleUserPollingService {
     const seconds = parseInt(match[3] || '0')
 
     return hours * 3600 + minutes * 60 + seconds
+  }
+
+  private chunk<T>(array: T[], size: number): T[][] {
+    const chunks: T[][] = []
+    for (let i = 0; i < array.length; i += size) {
+      chunks.push(array.slice(i, i + size))
+    }
+    return chunks
+  }
+
+  private async getMultipleShows(api: SpotifyAPI, showIds: string[]): Promise<SpotifyShow[]> {
+    // Spotify's "Get Multiple Shows" endpoint
+    const baseUrl = 'https://api.spotify.com/v1'
+    const params = new URLSearchParams({
+      ids: showIds.join(','),
+      market: 'US' // Required for episode availability
+    })
+
+    const response = await fetch(
+      `${baseUrl}/shows?${params.toString()}`,
+      {
+        headers: {
+          'Authorization': `Bearer ${api.getAccessToken()}`,
+          'Content-Type': 'application/json'
+        }
+      }
+    )
+
+    if (!response.ok) {
+      const error = await response.text()
+      throw new Error(`Spotify API error: ${response.status} ${error}`)
+    }
+
+    interface MultipleShowsResponse {
+      shows: (SpotifyShow | null)[]
+    }
+
+    const data = await response.json() as MultipleShowsResponse
+    
+    // Filter out null shows (deleted or unavailable)
+    return data.shows.filter((show): show is SpotifyShow => show !== null)
   }
 }


### PR DESCRIPTION
## Summary
- Implement batch fetching for Spotify shows (up to 50 at once)
- Only fetch episodes for shows with new content (smart caching)
- Reduce API calls by 10-20x for users with multiple podcasts

## Changes
### Batch Show Fetching
- Added `getMultipleShows()` method to fetch up to 50 shows in a single API call
- Uses Spotify's "Get Multiple Shows" endpoint for efficient metadata retrieval

### Smart Episode Detection
- Compare `total_episodes` count to detect which shows have new content
- Skip episode fetching for unchanged shows
- Process episode fetches with controlled concurrency (max 5 concurrent)

### API Call Management
- Track subrequest count to stay within Cloudflare's 50 request limit
- Gracefully stop processing when approaching the limit
- Provide detailed logging of API usage

## Performance Improvements
| Scenario | Before | After | Improvement |
|----------|--------|-------|-------------|
| 50 podcasts | 100+ API calls | 3-10 calls | ~10-20x |
| 20 podcasts | 40+ API calls | 2-5 calls | ~8-10x |

## Test Plan
- [x] Type checking passes
- [ ] Test with user having 1-5 podcasts
- [ ] Test with user having 20+ podcasts  
- [ ] Test with user having 50+ podcasts
- [ ] Verify API call reduction in logs
- [ ] Confirm no regression in feed item creation

🤖 Generated with [Claude Code](https://claude.ai/code)