### PR TITLE
fix: YouTube bookmark metadata extraction using oEmbed API

### DIFF
--- a/packages/shared/src/enhanced-metadata-extractor.ts
+++ b/packages/shared/src/enhanced-metadata-extractor.ts
@@ -219,8 +219,8 @@ export class EnhancedMetadataExtractor {
    */
   private parseEnhancedHtmlMetadata(html: string, url: string): EnhancedExtractedMetadata {
     // Parse HTML using linkedom for proper DOM manipulation
-    const parsed = parseHTML(html)
-    const document = parsed as unknown as LinkedOMDocument
+    const parsed = parseHTML(html) as any
+    const document = parsed.document as LinkedOMDocument
     
     // Extract JSON-LD structured data
     const jsonLdData = this.extractJsonLd(document)
@@ -819,13 +819,19 @@ export class EnhancedMetadataExtractor {
 
       const oembedData = await response.json() as YouTubeOEmbedResponse
 
-      // Also fetch the video page for additional metadata
-      const pageMetadata = await this.extractEnhancedWebMetadata(url, signal)
-
-      // Extract duration from page metadata if available
+      // Try to fetch the video page for additional metadata, but don't fail if it doesn't work
+      let pageMetadata: EnhancedExtractedMetadata | undefined
       let duration: number | undefined
-      if (pageMetadata.videoMetadata?.duration) {
-        duration = pageMetadata.videoMetadata.duration
+      
+      try {
+        pageMetadata = await this.extractEnhancedWebMetadata(url, signal)
+        // Extract duration from page metadata if available
+        if (pageMetadata?.videoMetadata?.duration) {
+          duration = pageMetadata.videoMetadata.duration
+        }
+      } catch (pageError) {
+        console.warn('Failed to extract additional YouTube page metadata:', pageError)
+        // Continue with oEmbed data only
       }
 
       // Parse creator information from oEmbed
@@ -846,12 +852,12 @@ export class EnhancedMetadataExtractor {
       }
 
       return {
-        title: oembedData.title || pageMetadata.title,
-        description: pageMetadata.description,
-        thumbnailUrl: oembedData.thumbnail_url || pageMetadata.thumbnailUrl,
-        faviconUrl: pageMetadata.faviconUrl,
-        publishedAt: pageMetadata.publishedAt,
-        language: pageMetadata.language,
+        title: oembedData.title || pageMetadata?.title || 'Untitled Video',
+        description: pageMetadata?.description,
+        thumbnailUrl: oembedData.thumbnail_url || pageMetadata?.thumbnailUrl,
+        faviconUrl: pageMetadata?.faviconUrl || 'https://www.youtube.com/favicon.ico',
+        publishedAt: pageMetadata?.publishedAt,
+        language: pageMetadata?.language,
         source: 'youtube',
         contentType: 'video',
         creator: this.resolveCreator(creator),


### PR DESCRIPTION
## Summary

- Fixed YouTube bookmark metadata extraction to properly display video titles instead of video IDs
- Improved error handling to gracefully fallback to oEmbed data when HTML parsing fails
- Corrected linkedom document extraction for Cloudflare Workers environment

## Problem

YouTube URLs were showing video IDs (like `dQw4w9WgXcQ`) as titles instead of the actual video title (like "Never Gonna Give You Up - Rick Astley"). This made bookmarks difficult to identify and organize.

## Root Cause

The issue was caused by incorrect DOM document extraction from linkedom's `parseHTML()` function in the Cloudflare Workers environment:

```typescript
// ❌ Before: Incorrect document access
const parsed = parseHTML(html)
const document = parsed as unknown as LinkedOMDocument

// ✅ After: Correct document access  
const parsed = parseHTML(html) as any
const document = parsed.document as LinkedOMDocument
```

Additionally, when HTML parsing failed completely, the entire metadata extraction would fail instead of falling back to the oEmbed API data.

## Solution

1. **Fixed linkedom document extraction**: Changed from casting `parsed` directly to accessing `parsed.document` property
2. **Added robust error handling**: Wrapped HTML parsing in try-catch to continue with oEmbed data when parsing fails
3. **Improved fallback logic**: Enhanced the fallback chain to ensure oEmbed titles are always used when available

## Test Plan

- [x] Test YouTube video bookmark creation shows proper video title
- [x] Test error handling when HTML parsing fails
- [x] Verify oEmbed API data is used as fallback
- [x] Confirm no regression in other metadata extraction functionality

🤖 Generated with [Claude Code](https://claude.ai/code)