### PR TITLE
Fix: Reduce batch size for bulk subscription inserts

### DIFF
--- a/packages/api/src/d1-subscription-repository.ts
+++ b/packages/api/src/d1-subscription-repository.ts
@@ -551,7 +551,9 @@ export class D1SubscriptionRepository implements SubscriptionRepository {
     if (userSubscriptions.length === 0) return
 
     const now = new Date()
-    const BATCH_SIZE = 50
+    // Reduced batch size to avoid D1/SQLite parameter limits
+    // Each record has 6 parameters, so 10 records = 60 parameters (well under limits)
+    const BATCH_SIZE = 10
 
     for (let i = 0; i < userSubscriptions.length; i += BATCH_SIZE) {
       const batch = userSubscriptions.slice(i, i + BATCH_SIZE)


### PR DESCRIPTION
## Summary
- Fixed database error when adding many subscriptions at once (e.g., 50+ Spotify podcasts)
- Reduced batch size from 50 to 10 records per insert to stay within D1/SQLite parameter limits

## Problem
When users tried to add all their Spotify subscriptions at once, they encountered a "Failed query" error. The issue was that the bulk insert was trying to insert too many records in a single SQL statement, exceeding D1's query parameter limits.

## Solution
- Reduced BATCH_SIZE from 50 to 10 in `batchCreateUserSubscriptions` method
- Each record has 6 parameters (id, userId, subscriptionId, isActive, createdAt, updatedAt)
- 10 records × 6 parameters = 60 total parameters per query (well under limits)
- Still maintains good performance through batching, just in smaller chunks

## Test Plan
- [ ] Test adding 50+ Spotify subscriptions at once
- [ ] Verify no database errors occur
- [ ] Confirm all subscriptions are successfully added
- [ ] Check performance is still acceptable

Fixes the bulk insert error reported in production logs.