### PR TITLE
Fix save input clearing issue

### DIFF
--- a/apps/web/src/components/save/SaveBookmarkInput.tsx
+++ b/apps/web/src/components/save/SaveBookmarkInput.tsx
@@ -24,9 +24,10 @@ export function SaveBookmarkInput({
     }
   }, [autoFocus])
 
-  // Clipboard auto-paste on mount
+  // Clipboard auto-paste on mount only
   useEffect(() => {
     const checkClipboard = async () => {
+      // Only check clipboard on initial mount when value is empty
       if (!value && navigator.clipboard && navigator.clipboard.readText) {
         try {
           const clipboardText = await navigator.clipboard.readText()
@@ -42,7 +43,8 @@ export function SaveBookmarkInput({
     }
     
     checkClipboard()
-  }, [value, onChange])
+    // Remove dependencies to only run once on mount
+  }, []) // eslint-disable-line react-hooks/exhaustive-deps
 
   return (
     <div className="relative">


### PR DESCRIPTION
## Summary
- Fixed an issue where the save input box wouldn't allow users to clear or erase characters
- Changed clipboard auto-paste to only run once on component mount instead of on every render

## Problem
The clipboard auto-paste effect in SaveBookmarkInput was running every time the component re-rendered with dependencies on value and onChange. This caused it to repeatedly check and potentially re-paste clipboard content when users tried to clear the input field, preventing normal text editing operations.

## Solution
Modified the useEffect hook for clipboard checking to:
1. Only run once on initial component mount (empty dependency array)
2. Added ESLint directive to suppress exhaustive-deps warning since we intentionally want this behavior
3. Added clarifying comment about the mount-only behavior

## Testing
- Users can now clear the input field using the X button
- Users can delete characters using backspace/delete keys  
- Clipboard auto-paste still works on initial page load
- TypeScript type checking passes