### PR TITLE
Add automated cleanup for Cloudflare preview workers

### DIFF
--- a/.github/workflows/cleanup-preview-workers.yml
+++ b/.github/workflows/cleanup-preview-workers.yml
@@ -1,0 +1,415 @@
+name: Cleanup Preview Workers
+
+on:
+  schedule:
+    # Runs at 2 AM UTC every day
+    - cron: '0 2 * * *'
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Dry run (only list workers that would be deleted)'
+        required: false
+        type: boolean
+        default: true
+      days_old:
+        description: 'Delete workers older than this many days (0 = delete all orphaned)'
+        required: false
+        type: number
+        default: 7
+      pattern:
+        description: 'Worker name pattern to match (default: zine-(api|web)-*)'
+        required: false
+        type: string
+        default: 'zine-(api|web)-'
+
+jobs:
+  cleanup-workers:
+    runs-on: ubuntu-latest
+    name: Cleanup Old Preview Workers
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: write
+    
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v1
+        with:
+          bun-version: latest
+      
+      - name: Install Wrangler
+        run: bun add -g wrangler
+      
+      - name: Get list of open PRs and recent merges
+        id: get-branches
+        uses: actions/github-script@v7
+        with:
+          script: |
+            // Get open PRs
+            const { data: prs } = await github.rest.pulls.list({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              per_page: 100
+            });
+            
+            // Get recently closed PRs (last 7 days)
+            const sevenDaysAgo = new Date();
+            sevenDaysAgo.setDate(sevenDaysAgo.getDate() - 7);
+            
+            const { data: recentlyClosedPRs } = await github.rest.pulls.list({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'closed',
+              sort: 'updated',
+              direction: 'desc',
+              per_page: 100
+            });
+            
+            // Filter PRs closed within the last 7 days
+            const recentPRs = recentlyClosedPRs.filter(pr => {
+              const closedAt = new Date(pr.closed_at);
+              return closedAt > sevenDaysAgo;
+            });
+            
+            // Combine branch names and sanitize
+            const allBranches = [...prs, ...recentPRs].map(pr => {
+              return {
+                original: pr.head.ref,
+                sanitized: pr.head.ref.replace(/[^a-zA-Z0-9-]/g, '-'),
+                state: pr.state,
+                closedAt: pr.closed_at
+              };
+            });
+            
+            console.log(`Found ${prs.length} open PRs and ${recentPRs.length} recently closed PRs`);
+            
+            // Group by protection status
+            const protectedBranches = allBranches.filter(b => 
+              b.state === 'open' || 
+              (b.closedAt && new Date(b.closedAt) > new Date(Date.now() - 24*60*60*1000))
+            ).map(b => b.sanitized);
+            
+            console.log('Protected branches:', protectedBranches.join(', '));
+            
+            return {
+              protected: protectedBranches,
+              all: allBranches
+            };
+      
+      - name: Get worker details from Cloudflare
+        id: get-workers
+        run: |
+          # Get the pattern from input or use default
+          PATTERN="${{ github.event.inputs.pattern || 'zine-(api|web)-' }}"
+          
+          # Get all workers with details
+          WORKERS_JSON=$(curl -s -X GET "https://api.cloudflare.com/client/v4/accounts/${{ secrets.CLOUDFLARE_ACCOUNT_ID }}/workers/services?per_page=100" \
+            -H "Authorization: Bearer ${{ secrets.CLOUDFLARE_API_TOKEN }}" \
+            -H "Content-Type: application/json")
+          
+          # Check if request was successful
+          SUCCESS=$(echo "$WORKERS_JSON" | jq -r '.success')
+          if [ "$SUCCESS" != "true" ]; then
+            echo "Failed to fetch workers from Cloudflare"
+            echo "$WORKERS_JSON"
+            exit 1
+          fi
+          
+          # Extract preview workers matching pattern
+          echo "$WORKERS_JSON" | jq -r --arg pattern "$PATTERN" '
+            .result[] | 
+            select(.name | test($pattern)) | 
+            {name: .name, created: .created_on, modified: .modified_on}
+          ' > /tmp/all_workers.json
+          
+          # Count workers
+          TOTAL_COUNT=$(cat /tmp/all_workers.json | jq -s 'length')
+          echo "total_preview_workers=$TOTAL_COUNT" >> $GITHUB_OUTPUT
+          
+          echo "Found $TOTAL_COUNT preview workers matching pattern: $PATTERN"
+          
+          # Display all workers
+          echo "All preview workers:"
+          cat /tmp/all_workers.json | jq -s '.'
+      
+      - name: Identify workers to delete
+        id: identify-deletions
+        run: |
+          # Get inputs
+          DAYS_OLD="${{ github.event.inputs.days_old || '7' }}"
+          DRY_RUN="${{ github.event.inputs.dry_run || 'false' }}"
+          
+          # Get protected branches from previous step
+          PROTECTED_BRANCHES='${{ steps.get-branches.outputs.result }}'
+          
+          # Create a script to process workers
+          cat > /tmp/process_workers.js << 'SCRIPT_EOF'
+          const fs = require('fs');
+          
+          // Read workers
+          const workersData = fs.readFileSync('/tmp/all_workers.json', 'utf8');
+          const workers = workersData.trim().split('\n').map(line => JSON.parse(line));
+          
+          // Parse protected branches
+          const branchData = JSON.parse(process.argv[2]);
+          const protectedBranches = branchData.protected;
+          const daysOld = parseInt(process.argv[3]);
+          
+          const now = new Date();
+          const cutoffDate = new Date(now.getTime() - (daysOld * 24 * 60 * 60 * 1000));
+          
+          const workersToDelete = [];
+          const workersToKeep = [];
+          
+          workers.forEach(worker => {
+            // Extract branch name from worker name
+            const match = worker.name.match(/^zine-(api|web)-(.+)$/);
+            if (!match) {
+              console.log(`Skipping worker with unexpected name format: ${worker.name}`);
+              return;
+            }
+            
+            const branchName = match[2];
+            const createdDate = new Date(worker.created);
+            const modifiedDate = new Date(worker.modified);
+            
+            // Determine if worker should be deleted
+            let shouldDelete = false;
+            let reason = '';
+            
+            // Check if branch is protected
+            const isProtected = protectedBranches.includes(branchName);
+            
+            if (isProtected) {
+              shouldDelete = false;
+              reason = 'Has active or recently closed PR';
+            } else if (daysOld > 0 && modifiedDate < cutoffDate) {
+              shouldDelete = true;
+              reason = `Last modified ${Math.floor((now - modifiedDate) / (24*60*60*1000))} days ago`;
+            } else if (daysOld === 0 && !isProtected) {
+              shouldDelete = true;
+              reason = 'No associated PR';
+            } else {
+              shouldDelete = false;
+              reason = 'Recently modified';
+            }
+            
+            const workerInfo = {
+              name: worker.name,
+              branch: branchName,
+              created: worker.created,
+              modified: worker.modified,
+              age_days: Math.floor((now - createdDate) / (24*60*60*1000)),
+              reason: reason
+            };
+            
+            if (shouldDelete) {
+              workersToDelete.push(workerInfo);
+            } else {
+              workersToKeep.push(workerInfo);
+            }
+          });
+          
+          // Sort by age
+          workersToDelete.sort((a, b) => b.age_days - a.age_days);
+          workersToKeep.sort((a, b) => a.age_days - b.age_days);
+          
+          // Write results
+          fs.writeFileSync('/tmp/workers_to_delete.json', JSON.stringify(workersToDelete, null, 2));
+          fs.writeFileSync('/tmp/workers_to_keep.json', JSON.stringify(workersToKeep, null, 2));
+          
+          // Generate summary
+          console.log('\n=== WORKERS TO DELETE ===');
+          workersToDelete.forEach(w => {
+            console.log(`- ${w.name} (${w.age_days} days old) - ${w.reason}`);
+          });
+          
+          console.log('\n=== WORKERS TO KEEP ===');
+          workersToKeep.forEach(w => {
+            console.log(`- ${w.name} (${w.age_days} days old) - ${w.reason}`);
+          });
+          
+          console.log(`\nSummary: ${workersToDelete.length} to delete, ${workersToKeep.length} to keep`);
+          
+          // Output for GitHub Actions
+          console.log(`::set-output name=delete_count::${workersToDelete.length}`);
+          console.log(`::set-output name=keep_count::${workersToKeep.length}`);
+          SCRIPT_EOF
+          
+          # Run the processing script
+          node /tmp/process_workers.js '${{ steps.get-branches.outputs.result }}' "$DAYS_OLD"
+          
+          # Set outputs
+          DELETE_COUNT=$(cat /tmp/workers_to_delete.json | jq 'length')
+          KEEP_COUNT=$(cat /tmp/workers_to_keep.json | jq 'length')
+          
+          echo "delete_count=$DELETE_COUNT" >> $GITHUB_OUTPUT
+          echo "keep_count=$KEEP_COUNT" >> $GITHUB_OUTPUT
+      
+      - name: Delete workers
+        if: steps.identify-deletions.outputs.delete_count != '0'
+        run: |
+          DRY_RUN="${{ github.event.inputs.dry_run || 'false' }}"
+          
+          echo "==============================================="
+          if [ "$DRY_RUN" = "true" ]; then
+            echo "🔍 DRY RUN MODE - No workers will be deleted"
+          else
+            echo "⚠️  DELETION MODE - Workers will be deleted"
+          fi
+          echo "==============================================="
+          
+          # Read workers to delete
+          WORKERS=$(cat /tmp/workers_to_delete.json | jq -r '.[].name')
+          
+          # Track results
+          DELETED=0
+          FAILED=0
+          
+          for worker in $WORKERS; do
+            if [ "$DRY_RUN" = "true" ]; then
+              echo "[DRY RUN] Would delete: $worker"
+            else
+              echo "Deleting: $worker"
+              
+              # Delete the worker
+              RESPONSE=$(curl -s -X DELETE "https://api.cloudflare.com/client/v4/accounts/${{ secrets.CLOUDFLARE_ACCOUNT_ID }}/workers/services/$worker" \
+                -H "Authorization: Bearer ${{ secrets.CLOUDFLARE_API_TOKEN }}" \
+                -H "Content-Type: application/json")
+              
+              SUCCESS=$(echo "$RESPONSE" | jq -r '.success')
+              if [ "$SUCCESS" = "true" ]; then
+                echo "  ✅ Deleted successfully"
+                DELETED=$((DELETED + 1))
+              else
+                echo "  ❌ Failed to delete"
+                ERROR=$(echo "$RESPONSE" | jq -r '.errors[0].message // "Unknown error"')
+                echo "  Error: $ERROR"
+                FAILED=$((FAILED + 1))
+              fi
+            fi
+          done
+          
+          if [ "$DRY_RUN" != "true" ]; then
+            echo ""
+            echo "Results: $DELETED deleted, $FAILED failed"
+            echo "deleted=$DELETED" >> $GITHUB_OUTPUT
+            echo "failed=$FAILED" >> $GITHUB_OUTPUT
+          fi
+      
+      - name: Generate report
+        if: always()
+        id: report
+        run: |
+          # Generate markdown report
+          cat > /tmp/report.md << 'REPORT_EOF'
+          # Preview Worker Cleanup Report
+          
+          **Date:** $(date -u '+%Y-%m-%d %H:%M:%S UTC')
+          **Mode:** ${{ github.event.inputs.dry_run == 'true' && 'Dry Run' || 'Live Deletion' }}
+          **Age Threshold:** ${{ github.event.inputs.days_old || '7' }} days
+          **Pattern:** `${{ github.event.inputs.pattern || 'zine-(api|web)-' }}`
+          
+          ## Summary
+          
+          - **Total Preview Workers:** ${{ steps.get-workers.outputs.total_preview_workers }}
+          - **Workers to Delete:** ${{ steps.identify-deletions.outputs.delete_count }}
+          - **Workers to Keep:** ${{ steps.identify-deletions.outputs.keep_count }}
+          
+          ## Workers Marked for Deletion
+          
+          REPORT_EOF
+          
+          if [ -f /tmp/workers_to_delete.json ] && [ "${{ steps.identify-deletions.outputs.delete_count }}" != "0" ]; then
+            echo '```json' >> /tmp/report.md
+            cat /tmp/workers_to_delete.json | jq -r '.[] | "- \(.name) (\(.age_days) days old) - \(.reason)"' >> /tmp/report.md
+            echo '```' >> /tmp/report.md
+          else
+            echo "_No workers to delete_" >> /tmp/report.md
+          fi
+          
+          echo "" >> /tmp/report.md
+          echo "## Workers Kept" >> /tmp/report.md
+          echo "" >> /tmp/report.md
+          
+          if [ -f /tmp/workers_to_keep.json ] && [ "${{ steps.identify-deletions.outputs.keep_count }}" != "0" ]; then
+            echo '```' >> /tmp/report.md
+            cat /tmp/workers_to_keep.json | jq -r '.[] | "- \(.name) (\(.age_days) days old) - \(.reason)"' | head -20 >> /tmp/report.md
+            if [ "${{ steps.identify-deletions.outputs.keep_count }}" -gt "20" ]; then
+              echo "... and $(({{ steps.identify-deletions.outputs.keep_count }} - 20)) more" >> /tmp/report.md
+            fi
+            echo '```' >> /tmp/report.md
+          else
+            echo "_No workers kept_" >> /tmp/report.md
+          fi
+          
+          # Save report
+          cat /tmp/report.md
+          
+          # Create output for issue/comment
+          REPORT=$(cat /tmp/report.md)
+          echo "report<<EOF" >> $GITHUB_OUTPUT
+          echo "$REPORT" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+      
+      - name: Post summary to issue (scheduled runs)
+        if: github.event_name == 'schedule' && steps.identify-deletions.outputs.delete_count != '0'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const report = `${{ steps.report.outputs.report }}`;
+            
+            // Check if there's an existing cleanup issue for today
+            const today = new Date().toISOString().split('T')[0];
+            const { data: issues } = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: 'cleanup-report',
+              state: 'open'
+            });
+            
+            const existingIssue = issues.find(issue => 
+              issue.title.includes(today)
+            );
+            
+            if (existingIssue) {
+              // Update existing issue
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: existingIssue.number,
+                body: report
+              });
+            } else {
+              // Create new issue
+              await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title: `[Automated] Preview Worker Cleanup Report - ${today}`,
+                body: report,
+                labels: ['cleanup-report', 'automated']
+              });
+            }
+      
+      - name: Create issue on failure
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const date = new Date().toISOString();
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: `[Alert] Preview Worker Cleanup Failed - ${date}`,
+              body: `The automated cleanup of preview workers failed.
+              
+              **Workflow Run:** ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}
+              **Date:** ${date}
+              **Triggered By:** ${{ github.event_name }}
+              
+              Please check the workflow logs for details.`,
+              labels: ['bug', 'automated', 'high-priority']
+            });


### PR DESCRIPTION
## Summary
- Adds GitHub Actions workflow to automatically clean up orphaned Cloudflare Workers preview environments
- Prevents accumulation of unused workers from closed/merged PRs
- Runs daily with configurable retention policies

## Problem
When PRs are created, preview environments are deployed to Cloudflare Workers with names like `zine-api-branch-name` and `zine-web-branch-name`. These workers persist even after PRs are closed or merged, leading to:
- Accumulation of unused resources
- Potential confusion about which workers are active
- Unnecessary Cloudflare resource usage

## Solution
This workflow automatically identifies and removes orphaned preview workers by:
1. Running daily at 2 AM UTC (configurable via cron)
2. Identifying all preview workers matching the pattern `zine-(api|web)-*`
3. Checking which branches have open PRs
4. Protecting workers from recently closed PRs (24 hours)
5. Deleting workers that have no associated active branches

## Features
- **Dry-run mode**: Default enabled for safety - test before deleting
- **Age-based deletion**: Configure retention period (default 7 days)
- **Manual trigger**: Run cleanup on-demand via GitHub Actions UI
- **Detailed reporting**: Creates GitHub issues with cleanup summaries
- **Failure alerts**: Automatically creates issues if cleanup fails
- **Configurable patterns**: Adjust worker name matching as needed

## Testing
1. After merge, go to Actions tab
2. Select "Cleanup Preview Workers" workflow
3. Click "Run workflow"
4. Keep "Dry run" checked for first run
5. Review the summary to see what would be deleted
6. Run again with dry run unchecked to perform actual cleanup

## Required Secrets
The workflow uses existing secrets:
- `CLOUDFLARE_API_TOKEN`
- `CLOUDFLARE_ACCOUNT_ID`

No additional configuration needed.