### PR TITLE
fix: handle Substack ImageObject format in creator avatar extraction

### DIFF
--- a/packages/shared/src/enhanced-metadata-extractor.ts
+++ b/packages/shared/src/enhanced-metadata-extractor.ts
@@ -761,6 +761,18 @@ export class EnhancedMetadataExtractor {
   }
 
   /**
+   * Extract image URL from various structured data formats
+   */
+  private extractImageUrl(image: any): string | undefined {
+    if (!image) return undefined
+    if (typeof image === 'string') return image
+    if (typeof image === 'object') {
+      return image.url || image.contentUrl || image.thumbnailUrl || undefined
+    }
+    return undefined
+  }
+
+  /**
    * TIER 1: Extract from structured data (JSON-LD, meta tags)
    */
   private extractFromStructuredData(jsonLdData: any[], metaTags: Map<string, string>): Creator | undefined {
@@ -775,7 +787,7 @@ export class EnhancedMetadataExtractor {
             name: author.name || 'Unknown Author',
             url: author.url,
             bio: author.description,
-            avatarUrl: author.image?.url || author.image
+            avatarUrl: this.extractImageUrl(author.image)
           }
         } else if (typeof author === 'string') {
           return {
@@ -794,7 +806,7 @@ export class EnhancedMetadataExtractor {
             name: creator.name || 'Unknown Creator',
             url: creator.url,
             bio: creator.description,
-            avatarUrl: creator.image?.url || creator.image
+            avatarUrl: this.extractImageUrl(creator.image)
           }
         }
       }
@@ -818,7 +830,7 @@ export class EnhancedMetadataExtractor {
               name,
               url: publisher.url,
               bio: publisher.description,
-              avatarUrl: publisher.logo?.url || publisher.image?.url
+              avatarUrl: this.extractImageUrl(publisher.logo) || this.extractImageUrl(publisher.image)
             }
           }
         }


### PR DESCRIPTION
## Summary
Fixes database insertion error when saving Substack posts where `[object Object]` was being stored in the `creator_thumbnail` column instead of the actual avatar URL.

## Root Cause
Substack returns creator avatar information in their JSON-LD structured data using the ImageObject format:
```json
"avatarUrl": {
  "@type": "ImageObject",
  "contentUrl": "https://...",
  "thumbnailUrl": "https://..."
}
```

The existing code only checked for `image.url` and fell back to the entire `image` object, which was then converted to the string `"[object Object]"` when stored in the database.

## Changes
- Added `extractImageUrl()` helper method that properly extracts URLs from various structured data image formats
- Updated three locations in `extractFromStructuredData()` to use the new helper:
  - Author image extraction
  - Creator image extraction  
  - Publisher logo/image extraction

The helper now checks for:
1. `image.url` - standard format
2. `image.contentUrl` - Substack's full-size image URL (preferred)
3. `image.thumbnailUrl` - Substack's thumbnail URL (fallback)

## Testing
- ✅ All existing tests pass
- ✅ Type checks pass
- ✅ Verified logic with unit test simulation

## Impact
Substack posts will now correctly store creator avatar URLs in the database, allowing them to be displayed in the UI.