### PR TITLE
fix: prevent adding bookmarked content to feed on subscription creation

### DIFF
--- a/packages/api/src/d1-feed-item-repository.ts
+++ b/packages/api/src/d1-feed-item-repository.ts
@@ -870,6 +870,28 @@ export class D1FeedItemRepository implements FeedItemRepository {
       totalEpisodes: row.totalEpisodes || undefined
     }
   }
+
+  /**
+   * Check if content IDs are already bookmarked by a user (including archived bookmarks).
+   * Returns a Set of content IDs that are already bookmarked.
+   */
+  async getBookmarkedContentIds(userId: string, contentIds: string[]): Promise<Set<string>> {
+    if (contentIds.length === 0) return new Set()
+
+    const bookmarkedContent = await this.db
+      .select({
+        contentId: schema.bookmarks.contentId
+      })
+      .from(schema.bookmarks)
+      .where(and(
+        eq(schema.bookmarks.userId, userId),
+        inArray(schema.bookmarks.contentId, contentIds)
+        // Note: We check both 'active' and 'archived' bookmarks
+        // by not filtering on status
+      ))
+
+    return new Set(bookmarkedContent.map(b => b.contentId))
+  }
 }
 
 // Type definitions for internal use

--- a/packages/api/src/services/initial-feed-population-service.ts
+++ b/packages/api/src/services/initial-feed-population-service.ts
@@ -100,22 +100,40 @@ export class InitialFeedPopulationService {
           }
         }
 
-        // Create user feed items
+        // Filter out items that are already bookmarked
+        let itemsAddedCount = 0
         if (feedItems.length > 0) {
-          const userFeedItems = feedItems.map(feedItem => ({
-            id: `${userId}-${feedItem.id}`,
-            userId,
-            feedItemId: feedItem.id,
-            isRead: false
-          }))
+          const provider = subscription.id.split('-')[0] || 'unknown'
+          const contentIds = feedItems.map(item => `${provider}-${item.externalId}`)
+          const bookmarkedContentIds = await this.feedItemRepository.getBookmarkedContentIds(userId, contentIds)
 
-          await this.feedItemRepository.createUserFeedItems(userFeedItems)
+          const unbookmarkedFeedItems = feedItems.filter((item) => {
+            const contentId = `${provider}-${item.externalId}`
+            return !bookmarkedContentIds.has(contentId)
+          })
+
+          // Create user feed items only for unbookmarked content
+          if (unbookmarkedFeedItems.length > 0) {
+            const userFeedItems = unbookmarkedFeedItems.map(feedItem => ({
+              id: `${userId}-${feedItem.id}`,
+              userId,
+              feedItemId: feedItem.id,
+              isRead: false
+            }))
+
+            await this.feedItemRepository.createUserFeedItems(userFeedItems)
+            itemsAddedCount = unbookmarkedFeedItems.length
+          }
+
+          if (feedItems.length - unbookmarkedFeedItems.length > 0) {
+            console.log(`[InitialFeedPopulation] Filtered out ${feedItems.length - unbookmarkedFeedItems.length} bookmarked items for ${subscription.title}`)
+          }
         }
 
         results.push({
           subscriptionId: subscription.id,
           subscriptionTitle: subscription.title,
-          itemsAdded: feedItems.length
+          itemsAdded: itemsAddedCount
         })
       } catch (error) {
         const subscription = await this.subscriptionRepository.getSubscription(subscriptionId)
@@ -174,22 +192,40 @@ export class InitialFeedPopulationService {
           }
         }
 
-        // Create user feed items
+        // Filter out items that are already bookmarked
+        let itemsAddedCount = 0
         if (feedItems.length > 0) {
-          const userFeedItems = feedItems.map(feedItem => ({
-            id: `${userId}-${feedItem.id}`,
-            userId,
-            feedItemId: feedItem.id,
-            isRead: false
-          }))
+          const provider = subscription.id.split('-')[0] || 'unknown'
+          const contentIds = feedItems.map(item => `${provider}-${item.externalId}`)
+          const bookmarkedContentIds = await this.feedItemRepository.getBookmarkedContentIds(userId, contentIds)
 
-          await this.feedItemRepository.createUserFeedItems(userFeedItems)
+          const unbookmarkedFeedItems = feedItems.filter((item) => {
+            const contentId = `${provider}-${item.externalId}`
+            return !bookmarkedContentIds.has(contentId)
+          })
+
+          // Create user feed items only for unbookmarked content
+          if (unbookmarkedFeedItems.length > 0) {
+            const userFeedItems = unbookmarkedFeedItems.map(feedItem => ({
+              id: `${userId}-${feedItem.id}`,
+              userId,
+              feedItemId: feedItem.id,
+              isRead: false
+            }))
+
+            await this.feedItemRepository.createUserFeedItems(userFeedItems)
+            itemsAddedCount = unbookmarkedFeedItems.length
+          }
+
+          if (feedItems.length - unbookmarkedFeedItems.length > 0) {
+            console.log(`[InitialFeedPopulation] Filtered out ${feedItems.length - unbookmarkedFeedItems.length} bookmarked items for ${subscription.title}`)
+          }
         }
 
         results.push({
           subscriptionId: subscription.id,
           subscriptionTitle: subscription.title,
-          itemsAdded: feedItems.length
+          itemsAdded: itemsAddedCount
         })
       } catch (error) {
         const subscription = await this.subscriptionRepository.getSubscription(subscriptionId)

--- a/packages/shared/src/repositories/feed-item-repository.ts
+++ b/packages/shared/src/repositories/feed-item-repository.ts
@@ -101,4 +101,7 @@ export interface FeedItemRepository {
   markAsRead(userId: string, feedItemId: string): Promise<UserFeedItem>
   markAsUnread(userId: string, feedItemId: string): Promise<UserFeedItem>
   addBookmarkToFeedItem(userId: string, feedItemId: string, bookmarkId: number): Promise<UserFeedItem>
+  
+  // Bookmark checking
+  getBookmarkedContentIds(userId: string, contentIds: string[]): Promise<Set<string>>
 }


### PR DESCRIPTION
## Summary
- Fixes bug where feed items were added when subscribing to a source, even if the content was already bookmarked (active or archived)
- Adds bookmark checking before creating user feed items to prevent duplicates

## Changes
- Added `getBookmarkedContentIds()` method to check for existing bookmarks by content ID
- Updated initial feed population service to filter out already-bookmarked content for both Spotify and YouTube subscriptions
- Enhanced logging to track how many items were filtered out during feed population