### PR TITLE
Filter YouTube Shorts from subscription feeds

### DIFF
--- a/packages/api/src/services/batch-processors/youtube-batch-processor.ts
+++ b/packages/api/src/services/batch-processors/youtube-batch-processor.ts
@@ -321,15 +321,20 @@ export class YouTubeBatchProcessor extends BaseBatchProcessor {
       // Extract channel information for creator metadata
       const channelStats = channel as ChannelWithStats
 
-      const newItems: FeedItem[] = videos.map(video => {
+      const newItems: FeedItem[] = videos
+        .filter(video => {
+          // Filter out YouTube Shorts (videos <= 180 seconds)
+          const durationSeconds = YouTubeAPI.parseDuration(video.contentDetails.duration)
+          return !durationSeconds || durationSeconds > 180
+        })
+        .map(video => {
         // Determine content type based on duration and live status
         const durationSeconds = YouTubeAPI.parseDuration(video.contentDetails.duration)
         let contentType: string = 'video'
         if (video.snippet.liveBroadcastContent === 'live') {
           contentType = 'live'
-        } else if (durationSeconds && durationSeconds <= 60) {
-          contentType = 'short'
         }
+        // Note: Shorts (<=180s) are already filtered out above
 
         // Calculate popularity score (0-100 normalized)
         let popularityScore: number | undefined


### PR DESCRIPTION
## Summary
- Filter YouTube Shorts (videos ≤180 seconds) from subscription feeds to prevent them from being saved to the database
- Update Shorts detection threshold from 60s to 180s to align with YouTube's current 3-minute maximum definition (as of October 15, 2024)