### PR TITLE
fix: improve hide feed item implementation with proper ID lookup and query filtering

### DIFF
--- a/apps/mobile/app/(app)/(tabs)/index.tsx
+++ b/apps/mobile/app/(app)/(tabs)/index.tsx
@@ -84,12 +84,7 @@ export default function HomeScreen() {
 
         {/* Feed Section - Only show when authenticated and has new items */}
         {isLoaded && isSignedIn && (
-          <View style={styles.section}>
-            <View style={styles.sectionHeader}>
-              <Text style={[styles.sectionTitle, { color: colors.foreground }]}>From your Feed</Text>
-            </View>
-            <FeedSection onRefresh={onRefresh} />
-          </View>
+          <FeedSection onRefresh={onRefresh} />
         )}
         
         {/* Recent Bookmarks Section - Only show when authenticated */}

--- a/apps/mobile/components/FeedSection.tsx
+++ b/apps/mobile/components/FeedSection.tsx
@@ -221,31 +221,36 @@ export const FeedSection = React.memo<FeedSectionProps>(({ onRefresh }) => {
   }
 
   return (
-    <View style={styles.section}>
-      <ScrollView
-        horizontal
-        showsHorizontalScrollIndicator={false}
-        contentContainerStyle={styles.scrollContent}
-        snapToInterval={296}
-        snapToAlignment="start"
-        decelerationRate="fast"
-      >
-        {feedItems.map((item, index) => (
-          <View
-            key={item.id}
-            style={{
-              marginRight: index === feedItems.length - 1 ? 0 : 16,
-            }}
-          >
-            <FeedCard
-              item={item}
-              onPress={() => {
-                router.push(`/content/${item.feedItem.contentId}?feedItemId=${item.id}`);
+    <View style={styles.sectionContainer}>
+      <View style={styles.sectionHeader}>
+        <Text style={[styles.sectionTitle, { color: colors.foreground }]}>From your Feed</Text>
+      </View>
+      <View style={styles.section}>
+        <ScrollView
+          horizontal
+          showsHorizontalScrollIndicator={false}
+          contentContainerStyle={styles.scrollContent}
+          snapToInterval={296}
+          snapToAlignment="start"
+          decelerationRate="fast"
+        >
+          {feedItems.map((item, index) => (
+            <View
+              key={item.id}
+              style={{
+                marginRight: index === feedItems.length - 1 ? 0 : 16,
               }}
-            />
-          </View>
-        ))}
-      </ScrollView>
+            >
+              <FeedCard
+                item={item}
+                onPress={() => {
+                  router.push(`/content/${item.feedItem.contentId}?feedItemId=${item.id}`);
+                }}
+              />
+            </View>
+          ))}
+        </ScrollView>
+      </View>
     </View>
   );
 });
@@ -253,6 +258,20 @@ export const FeedSection = React.memo<FeedSectionProps>(({ onRefresh }) => {
 FeedSection.displayName = 'FeedSection';
 
 const styles = StyleSheet.create({
+  sectionContainer: {
+    marginTop: 20,
+  },
+  sectionHeader: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    paddingHorizontal: 16,
+    marginBottom: 12,
+  },
+  sectionTitle: {
+    fontSize: 24,
+    fontWeight: '700',
+  },
   section: {
     paddingBottom: 16,
   },

--- a/packages/api/src/d1-feed-item-repository.ts
+++ b/packages/api/src/d1-feed-item-repository.ts
@@ -270,6 +270,16 @@ export class D1FeedItemRepository implements FeedItemRepository {
     return results.length > 0 ? this.mapUserFeedItem(results[0]) : null
   }
 
+  async getUserFeedItemById(id: string): Promise<UserFeedItem | null> {
+    const results = await this.db
+      .select()
+      .from(schema.userFeedItems)
+      .where(eq(schema.userFeedItems.id, id))
+      .limit(1)
+    
+    return results.length > 0 ? this.mapUserFeedItem(results[0]) : null
+  }
+
   async getUserFeedItems(
     userId: string,
     options?: {
@@ -368,7 +378,8 @@ export class D1FeedItemRepository implements FeedItemRepository {
       .innerJoin(schema.subscriptions, eq(schema.feedItems.subscriptionId, schema.subscriptions.id))
       .where(and(
         eq(schema.userFeedItems.userId, userId),
-        eq(schema.feedItems.subscriptionId, subscriptionId)
+        eq(schema.feedItems.subscriptionId, subscriptionId),
+        eq(schema.userFeedItems.isHidden, false)
       ))
       .$dynamic()
 
@@ -377,6 +388,7 @@ export class D1FeedItemRepository implements FeedItemRepository {
         eq(schema.userFeedItems.userId, userId),
         eq(schema.feedItems.subscriptionId, subscriptionId),
         eq(schema.userFeedItems.isRead, false),
+        eq(schema.userFeedItems.isHidden, false),
         isNull(schema.userFeedItems.bookmarkId)
       ))
     }
@@ -448,6 +460,7 @@ export class D1FeedItemRepository implements FeedItemRepository {
       .select({
         subscription: schema.subscriptions,
         unreadCount: schema.userFeedItems.isRead,
+        isHidden: schema.userFeedItems.isHidden,
         lastUpdated: schema.content.publishedAt
       })
       .from(schema.subscriptions)
@@ -476,7 +489,10 @@ export class D1FeedItemRepository implements FeedItemRepository {
       const subscription = subscriptionMap.get(subId)!
       
       // Count unread items (userFeedItem.isRead is false or null means unread)
-      if (row.unreadCount === false || row.unreadCount === null) {
+      // Exclude hidden items from the count
+      const isUnread = row.unreadCount === false || row.unreadCount === null
+      const isHidden = row.isHidden === true
+      if (isUnread && !isHidden) {
         subscription.unreadCount++
       }
       
@@ -551,13 +567,17 @@ export class D1FeedItemRepository implements FeedItemRepository {
       .innerJoin(schema.feedItems, eq(schema.userFeedItems.feedItemId, schema.feedItems.id))
       .innerJoin(schema.content, eq(schema.feedItems.contentId, schema.content.id))
       .innerJoin(schema.subscriptions, eq(schema.feedItems.subscriptionId, schema.subscriptions.id))
-      .where(eq(schema.userFeedItems.userId, userId))
+      .where(and(
+        eq(schema.userFeedItems.userId, userId),
+        eq(schema.userFeedItems.isHidden, false)
+      ))
       .$dynamic()
 
     if (unreadOnly) {
       query = query.where(and(
         eq(schema.userFeedItems.userId, userId),
         eq(schema.userFeedItems.isRead, false),
+        eq(schema.userFeedItems.isHidden, false),
         isNull(schema.userFeedItems.bookmarkId)
       ))
     }

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -1199,20 +1199,21 @@ app.put('/api/v1/feed/:itemId/hide', authMiddleware, async (c) => {
       id: auth.userId
     })
     
-    // Extract the actual feedItemId from the userFeedItemId if needed
-    // The itemId might be in format: userId-feedItemId-timestamp
+    // The itemId could be either a feedItemId or a userFeedItemId
+    // Try to look it up as a userFeedItemId first
     let feedItemId = itemId
     
-    // Check if this looks like a userFeedItemId (contains userId prefix)
-    if (itemId.startsWith(auth.userId + '-')) {
-      // Extract the feedItemId part (everything after userId- and before the last timestamp)
-      const parts = itemId.substring(auth.userId.length + 1).split('-')
-      if (parts.length >= 3) {
-        // Remove the last part (timestamp) and rejoin
-        parts.pop() // Remove timestamp
-        feedItemId = parts.join('-')
-        console.log(`Extracted feedItemId: ${feedItemId} from userFeedItemId: ${itemId}`)
+    // Check if this is a userFeedItemId by looking it up in the database
+    const userFeedItem = await feedItemRepository.getUserFeedItemById(itemId)
+    if (userFeedItem) {
+      // Verify it belongs to the current user
+      if (userFeedItem.userId !== auth.userId) {
+        return c.json({ error: 'Unauthorized' }, 403)
       }
+      feedItemId = userFeedItem.feedItemId
+      console.log(`Found userFeedItem ${itemId}, extracted feedItemId: ${feedItemId}`)
+    } else {
+      console.log(`No userFeedItem found for ${itemId}, treating as feedItemId`)
     }
     
     await feedItemRepository.hideItem(auth.userId, feedItemId)
@@ -1238,20 +1239,21 @@ app.put('/api/v1/feed/:itemId/unhide', authMiddleware, async (c) => {
       id: auth.userId
     })
     
-    // Extract the actual feedItemId from the userFeedItemId if needed
-    // The itemId might be in format: userId-feedItemId-timestamp
+    // The itemId could be either a feedItemId or a userFeedItemId
+    // Try to look it up as a userFeedItemId first
     let feedItemId = itemId
     
-    // Check if this looks like a userFeedItemId (contains userId prefix)
-    if (itemId.startsWith(auth.userId + '-')) {
-      // Extract the feedItemId part (everything after userId- and before the last timestamp)
-      const parts = itemId.substring(auth.userId.length + 1).split('-')
-      if (parts.length >= 3) {
-        // Remove the last part (timestamp) and rejoin
-        parts.pop() // Remove timestamp
-        feedItemId = parts.join('-')
-        console.log(`Extracted feedItemId: ${feedItemId} from userFeedItemId: ${itemId}`)
+    // Check if this is a userFeedItemId by looking it up in the database
+    const userFeedItem = await feedItemRepository.getUserFeedItemById(itemId)
+    if (userFeedItem) {
+      // Verify it belongs to the current user
+      if (userFeedItem.userId !== auth.userId) {
+        return c.json({ error: 'Unauthorized' }, 403)
       }
+      feedItemId = userFeedItem.feedItemId
+      console.log(`Found userFeedItem ${itemId}, extracted feedItemId: ${feedItemId}`)
+    } else {
+      console.log(`No userFeedItem found for ${itemId}, treating as feedItemId`)
     }
     
     await feedItemRepository.unhideItem(auth.userId, feedItemId)

--- a/packages/shared/src/repositories/feed-item-repository.ts
+++ b/packages/shared/src/repositories/feed-item-repository.ts
@@ -91,6 +91,7 @@ export interface FeedItemRepository {
 
   // User feed item operations
   getUserFeedItem(userId: string, feedItemId: string): Promise<UserFeedItem | null>
+  getUserFeedItemById(id: string): Promise<UserFeedItem | null>
   getUserFeedItems(userId: string, options?: {
     isRead?: boolean
     subscriptionIds?: string[]


### PR DESCRIPTION
## Summary
- Fixes hide feed item functionality to properly exclude hidden items from all feed queries using database lookups instead of unreliable string parsing
- Refactors FeedSection component to include its own section header for better encapsulation

## Changes
- **API**: Added `getUserFeedItemById` method to repository interface for proper userFeedItem lookups
- **API**: Fixed hide/unhide endpoints to use database lookup instead of string parsing to extract feedItemId from userFeedItemId
- **API**: Excluded hidden items from all feed queries including `getUserFeedItems`, `getUserFeedItemsBySubscription`, and `getSubscriptionsWithUnreadCount`
- **API**: Fixed unread count calculation to exclude hidden items from the count
- **Mobile**: Moved "From your Feed" section header inside FeedSection component for better encapsulation

## Testing
- ✅ Lint checks passed
- ✅ Type checks passed
- ✅ Build successful