### PR TITLE
Remove category filter tabs from mobile home screen

### DIFF
--- a/apps/mobile/app/(app)/(tabs)/index.tsx
+++ b/apps/mobile/app/(app)/(tabs)/index.tsx
@@ -9,13 +9,11 @@ import { FeedSection } from '../../../components/FeedSection';
 import { useQueryClient } from '@tanstack/react-query';
 import { Feather } from '@expo/vector-icons';
 import { HomeHeader } from '../../../components/HomeHeader';
-import { CategoryTabs, CategoryType } from '../../../components/CategoryTabs';
 import { useTheme } from '../../../contexts/theme';
 import { useRefreshFeed } from '../../../hooks/useRefreshFeed';
 
 export default function HomeScreen() {
   const [refreshing, setRefreshing] = useState(false);
-  const [selectedCategory, setSelectedCategory] = useState<CategoryType>('all');
   const { isSignedIn, isLoaded } = useAuth();
   const queryClient = useQueryClient();
   const router = useRouter();
@@ -60,10 +58,6 @@ export default function HomeScreen() {
   return (
     <View style={[styles.container, { backgroundColor: colors.background }]}>
       <HomeHeader />
-      <CategoryTabs
-        selectedCategory={selectedCategory}
-        onCategoryChange={setSelectedCategory}
-      />
       <ScrollView
         style={styles.scrollView} 
         contentContainerStyle={styles.content}


### PR DESCRIPTION
## Summary
- Removes the horizontal category filter tabs (All, Videos, Podcasts, Articles, Posts) from the mobile app home screen to simplify the UI
- Cleans up unused state and imports since the filter wasn't connected to any data filtering logic

## Changes
- Removed CategoryTabs component from home screen
- Removed unused selectedCategory state
- Removed related imports

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Remove `CategoryTabs` and related unused state/imports from the mobile home screen.
> 
> - **Mobile**:
>   - **Home screen (`apps/mobile/app/(app)/(tabs)/index.tsx`)**:
>     - Remove `CategoryTabs` UI and `selectedCategory` state.
>     - Remove related unused imports.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 743b9a98e2f848183fd7eb37950fe7d5b2ffd5fd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->